### PR TITLE
[Feat] HotIssueHeader 컴포넌트 구현

### DIFF
--- a/public/icons/ic_hash_blue.svg
+++ b/public/icons/ic_hash_blue.svg
@@ -1,0 +1,3 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5.33325 12H26.6666M5.33325 20H26.6666M13.3333 4L10.6666 28M21.3333 4L18.6666 28" stroke="#23A2FF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/ic_hash_red.svg
+++ b/public/icons/ic_hash_red.svg
@@ -1,0 +1,3 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5.33325 12H26.6666M5.33325 20H26.6666M13.3333 4L10.6666 28M21.3333 4L18.6666 28" stroke="#FF4848" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/app/(home)/components/hotIssueSection/hotIssueHeader/HotIssueHeader.tsx
+++ b/src/app/(home)/components/hotIssueSection/hotIssueHeader/HotIssueHeader.tsx
@@ -6,7 +6,7 @@ interface HotIssueHeaderPropTypes {
   keyword: string;
 }
 
-const IDEOLOGY_ICON_PATHS: Record<string, string> = {
+const IDEOLOGY_ICON_PATHS: Record<HotIssueHeaderPropTypes['ideology'], string> = {
   progressive: '/icons/ic_hash_blue.svg',
   conservative: '/icons/ic_hash_red.svg',
 };

--- a/src/app/(home)/components/hotIssueSection/hotIssueHeader/HotIssueHeader.tsx
+++ b/src/app/(home)/components/hotIssueSection/hotIssueHeader/HotIssueHeader.tsx
@@ -2,8 +2,8 @@ import Image from 'next/image';
 import * as styles from './hotIssueHeader.css';
 
 interface HotIssueHeaderPropTypes {
-  ideology: string;
-  hotIssueKeyword: string;
+  ideology: 'progressive' | 'conservative';
+  keyword: string;
 }
 
 const IDEOLOGY_ICON_PATHS: Record<string, string> = {
@@ -11,7 +11,7 @@ const IDEOLOGY_ICON_PATHS: Record<string, string> = {
   conservative: '/icons/ic_hash_red.svg',
 };
 
-const HotIssueHeader = ({ ideology, hotIssueKeyword }: HotIssueHeaderPropTypes) => {
+const HotIssueHeader = ({ ideology, keyword }: HotIssueHeaderPropTypes) => {
   const iconPath = IDEOLOGY_ICON_PATHS[ideology] ?? IDEOLOGY_ICON_PATHS.conservative;
 
   return (
@@ -25,7 +25,7 @@ const HotIssueHeader = ({ ideology, hotIssueKeyword }: HotIssueHeaderPropTypes) 
           sizes="(max-width: 768px) 1.25rem, (max-width: 1024px) 1.625rem, 2rem"
         />
       </span>
-      <p className={styles.hotIssueKeyword}>{hotIssueKeyword}</p>
+      <p className={styles.keyword}>{keyword}</p>
     </div>
   );
 };

--- a/src/app/(home)/components/hotIssueSection/hotIssueHeader/HotIssueHeader.tsx
+++ b/src/app/(home)/components/hotIssueSection/hotIssueHeader/HotIssueHeader.tsx
@@ -19,7 +19,7 @@ const HotIssueHeader = ({ ideology, keyword }: HotIssueHeaderPropTypes) => {
       <span className={styles.iconWrapper}>
         <Image
           src={iconPath}
-          alt="hotIssueHeader"
+          alt=""
           className={styles.icon}
           fill
           sizes="(max-width: 768px) 1.25rem, (max-width: 1024px) 1.625rem, 2rem"

--- a/src/app/(home)/components/hotIssueSection/hotIssueHeader/HotIssueHeader.tsx
+++ b/src/app/(home)/components/hotIssueSection/hotIssueHeader/HotIssueHeader.tsx
@@ -1,0 +1,33 @@
+import Image from 'next/image';
+import * as styles from './hotIssueHeader.css';
+
+interface HotIssueHeaderPropTypes {
+  ideology: string;
+  hotIssueKeyword: string;
+}
+
+const IDEOLOGY_ICON_PATHS: Record<string, string> = {
+  progressive: '/icons/ic_hash_blue.svg',
+  conservative: '/icons/ic_hash_red.svg',
+};
+
+const HotIssueHeader = ({ ideology, hotIssueKeyword }: HotIssueHeaderPropTypes) => {
+  const iconPath = IDEOLOGY_ICON_PATHS[ideology] ?? IDEOLOGY_ICON_PATHS.conservative;
+
+  return (
+    <div className={styles.container}>
+      <span className={styles.iconWrapper}>
+        <Image
+          src={iconPath}
+          alt="hotIssueHeader"
+          className={styles.icon}
+          fill
+          sizes="(max-width: 768px) 1.25rem, (max-width: 1024px) 1.625rem, 2rem"
+        />
+      </span>
+      <p className={styles.hotIssueKeyword}>{hotIssueKeyword}</p>
+    </div>
+  );
+};
+
+export default HotIssueHeader;

--- a/src/app/(home)/components/hotIssueSection/hotIssueHeader/hotIssueHeader.css.ts
+++ b/src/app/(home)/components/hotIssueSection/hotIssueHeader/hotIssueHeader.css.ts
@@ -1,0 +1,49 @@
+import { style } from '@vanilla-extract/css';
+import { color, typography, media } from '@/shared/styles';
+
+export const container = style({
+  margin: '2.5rem',
+  minWidth: 'max-content',
+  padding: '0.9375rem',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'start',
+  gap: '1.25rem',
+  boxShadow: '0 0 2px 0 rgba(17, 17, 17, 0.20)',
+  borderRadius: '0.3125rem',
+});
+
+export const iconWrapper = style({
+  position: 'relative',
+  width: '2rem',
+  height: '2rem',
+  '@media': {
+    [media.tablet]: {
+      width: '1.625rem',
+      height: '1.625rem',
+    },
+    [media.mobile]: {
+      width: '1.25rem',
+      height: '1.25rem',
+    },
+  },
+});
+
+export const icon = style({
+  objectFit: 'contain',
+});
+
+export const hotIssueKeyword = style({
+  ...typography.correction,
+  ...typography.desktop.h3,
+  color: color.text.main,
+  whiteSpace: 'nowrap',
+  '@media': {
+    [media.tablet]: {
+      ...typography.tablet.h3,
+    },
+    [media.mobile]: {
+      ...typography.phone.h3,
+    },
+  },
+});

--- a/src/app/(home)/components/hotIssueSection/hotIssueHeader/hotIssueHeader.css.ts
+++ b/src/app/(home)/components/hotIssueSection/hotIssueHeader/hotIssueHeader.css.ts
@@ -2,8 +2,7 @@ import { style } from '@vanilla-extract/css';
 import { color, typography, media } from '@/shared/styles';
 
 export const container = style({
-  margin: '2.5rem',
-  minWidth: 'max-content',
+  width: '100%',
   padding: '0.9375rem',
   display: 'flex',
   alignItems: 'center',

--- a/src/app/(home)/components/hotIssueSection/hotIssueHeader/hotIssueHeader.css.ts
+++ b/src/app/(home)/components/hotIssueSection/hotIssueHeader/hotIssueHeader.css.ts
@@ -33,7 +33,7 @@ export const icon = style({
   objectFit: 'contain',
 });
 
-export const hotIssueKeyword = style({
+export const keyword = style({
   ...typography.correction,
   ...typography.desktop.h3,
   color: color.text.main,


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #22 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- `HotIssueHeader` 컴포넌트를 구현
- 헤더에서 사용하는 해시 아이콘 에셋 추가 (`public/icons/` 경로에 추가)
  - ic_hash_blue.svg
  - ic_hash_red.svg

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
### HotIssueHeader 컴포넌트 사용 방법
```ts
import HotIssueHeader from './components/hotIssueSection/hotIssueHeader/HotIssueHeader';

export default function Home() {
  return (
    <>
      <HotIssueHeader ideology="progressive" keyword="키워드" />
      <HotIssueHeader ideology="conservative" keyword="키워드" />
    </>
  );
}
```
**prop 종류**
- `ideology`
  - 핫이슈 해시 아이콘 경로 분기 지표
  - 'progressive' | 'conservative'
- `keyword`
  - 핫이슈 키워드

## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| 구현 화면 |
|--|
| <img width="353" height="176" alt="image" src="https://github.com/user-attachments/assets/f11b271e-6a5f-4a54-b053-5c27c88251d6" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 핫 이슈 섹션에 새로운 헤더 컴포넌트가 추가되었습니다. 진보(progressive)·보수(conservative) 아이콘과 키워드를 표시하며, 아이콘은 유효하지 않을 경우 기본값으로 대체됩니다. 반응형 레이아웃과 텍스트 처리로 다양한 화면에서 안정적으로 표시됩니다.
* **스타일**
  * 헤더 전용 스타일이 추가되어 레이아웃, 아이콘 크기 및 반응형 타이포그래피를 적용합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->