### PR TITLE
[Feat] ScopePercentBar 컴포넌트 구현

### DIFF
--- a/src/common/components/percentBar/ScopePercentBar.tsx
+++ b/src/common/components/percentBar/ScopePercentBar.tsx
@@ -13,12 +13,17 @@ const ScopePercentBar = ({
   conservativePercent,
   size,
 }: ScopePercentBarPropTypes) => {
-  // 퍼센트 검증
-  const total = progressivePercent + centerPercent + conservativePercent;
+  // 퍼센트 검증 + 음수/비정상 수 정제
+  const safeProgressive = Number.isFinite(progressivePercent) ? Math.max(0, progressivePercent) : 0;
+  const safeCenter = Number.isFinite(centerPercent) ? Math.max(0, centerPercent) : 0;
+  const safeConservative = Number.isFinite(conservativePercent)
+    ? Math.max(0, conservativePercent)
+    : 0;
+  const total = safeProgressive + safeCenter + safeConservative;
 
-  const validProgressive = total ? (progressivePercent / total) * 100 : 0;
-  const validCenter = total ? (centerPercent / total) * 100 : 0;
-  const validConservative = total ? (conservativePercent / total) * 100 : 0;
+  const validProgressive = total ? (safeProgressive / total) * 100 : 0;
+  const validCenter = total ? (safeCenter / total) * 100 : 0;
+  const validConservative = total ? (safeConservative / total) * 100 : 0;
 
   const containerClass = `${styles.baseContainer} ${styles.containerVariants[size]}`;
 

--- a/src/common/components/percentBar/ScopePercentBar.tsx
+++ b/src/common/components/percentBar/ScopePercentBar.tsx
@@ -1,0 +1,53 @@
+import * as styles from './scopePercentBar.css';
+
+export interface ScopePercentBarPropTypes {
+  progressivePercent: number;
+  centerPercent: number;
+  conservativePercent: number;
+  size: keyof typeof styles.containerVariants; // 타입 자동화 (스타일에서 동기화)
+}
+
+const ScopePercentBar = ({
+  progressivePercent,
+  centerPercent,
+  conservativePercent,
+  size,
+}: ScopePercentBarPropTypes) => {
+  // 퍼센트 검증
+  const total = progressivePercent + centerPercent + conservativePercent;
+
+  const validProgressive = total ? (progressivePercent / total) * 100 : 0;
+  const validCenter = total ? (centerPercent / total) * 100 : 0;
+  const validConservative = total ? (conservativePercent / total) * 100 : 0;
+
+  const containerClass = `${styles.baseContainer} ${styles.containerVariants[size]}`;
+
+  // 렌더마다 바뀌는 동적 값 (각 이념 분포)
+  const segments = [
+    { value: validProgressive, color: 'progressive' as const },
+    { value: validCenter, color: 'center' as const },
+    { value: validConservative, color: 'conservative' as const },
+  ];
+
+  return (
+    <div
+      className={containerClass}
+      role="img"
+      aria-label={`이념 분포 - 진보 ${validProgressive.toFixed(1)}%, 중립 ${validCenter.toFixed(1)}%, 보수 ${validConservative.toFixed(1)}%`}
+    >
+      {segments.map(
+        ({ value, color }) =>
+          value > 0 && (
+            <div
+              key={color}
+              className={styles.segment({ color })}
+              style={{ '--flex': value } as React.CSSProperties} // 스타일 직접 건드리지 않고 변수만 전달
+              aria-hidden="true"
+            />
+          ),
+      )}
+    </div>
+  );
+};
+
+export default ScopePercentBar;

--- a/src/common/components/percentBar/constants.ts
+++ b/src/common/components/percentBar/constants.ts
@@ -1,0 +1,27 @@
+import { color } from '@/shared/styles/color.css';
+
+export const SCOPE_PERCENT_BAR_COLORS = {
+  progressive: color.brand.progressive,
+  center: color.brand.center,
+  conservative: color.brand.conservative,
+} as const;
+
+/**
+ * 이념 퍼센트 분포 관련 스타일 상수화
+ */
+
+export const SCOPE_PERCENT_BAR_SIZE_STYLE = {
+  mobile: {
+    SMALL: { width: '14.375rem', height: '0.9375rem', borderRadius: '0.1875rem' },
+    LARGE: { width: '21.875rem', height: '1.875rem', borderRadius: '0.3125rem' },
+  },
+  tablet: {
+    SMALL: { width: '13.25rem', height: '0.9375rem', borderRadius: '0.1875rem' },
+    MEDIUM: { width: '29.9375rem', height: '0.9375rem', borderRadius: '0.1875rem' },
+    LARGE: { width: '43rem', height: '1.875rem', borderRadius: '0.3125rem' },
+  },
+  desktop: {
+    SMALL: { width: '15.75rem', height: '0.9375rem', borderRadius: '0.1875rem' },
+    LARGE: { width: '52.8125rem', height: '1.875rem', borderRadius: '0.3125rem' },
+  },
+} as const;

--- a/src/common/components/percentBar/scopePercentBar.css.ts
+++ b/src/common/components/percentBar/scopePercentBar.css.ts
@@ -1,0 +1,56 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+import { SCOPE_PERCENT_BAR_SIZE_STYLE, SCOPE_PERCENT_BAR_COLORS } from './constants';
+import { media } from '@/shared/styles';
+
+export const baseContainer = style({
+  display: 'flex',
+  overflow: 'hidden',
+});
+
+export const containerVariants = styleVariants({
+  small: {
+    ...SCOPE_PERCENT_BAR_SIZE_STYLE.desktop.SMALL,
+    '@media': {
+      [media.tablet]: {
+        ...SCOPE_PERCENT_BAR_SIZE_STYLE.tablet.SMALL,
+      },
+      [media.mobile]: {
+        ...SCOPE_PERCENT_BAR_SIZE_STYLE.mobile.SMALL,
+      },
+    },
+  },
+  medium: {
+    '@media': {
+      [media.tablet]: {
+        ...SCOPE_PERCENT_BAR_SIZE_STYLE.tablet.MEDIUM,
+      },
+    },
+  },
+  large: {
+    ...SCOPE_PERCENT_BAR_SIZE_STYLE.desktop.LARGE,
+    '@media': {
+      [media.tablet]: {
+        ...SCOPE_PERCENT_BAR_SIZE_STYLE.tablet.LARGE,
+      },
+      [media.mobile]: {
+        ...SCOPE_PERCENT_BAR_SIZE_STYLE.mobile.LARGE,
+      },
+    },
+  },
+});
+
+export const segment = recipe({
+  base: {
+    height: '100%',
+    flex: 'var(--flex)',
+    transition: 'flex 0.3s ease-in-out',
+  },
+  variants: {
+    color: {
+      progressive: { backgroundColor: SCOPE_PERCENT_BAR_COLORS.progressive },
+      center: { backgroundColor: SCOPE_PERCENT_BAR_COLORS.center },
+      conservative: { backgroundColor: SCOPE_PERCENT_BAR_COLORS.conservative },
+    },
+  },
+});


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #31 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- ScopePercentBar 구현
- 이념 분포 색상 테마 및 스타일 상수 정의
- 반응형 사이즈 타입 및 스타일 정의 
  - desktop(`small`, `large`) / tablet(`small`, `medium`, `large`) / mobile(`small`, `large`)


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
#### ScopePercentBar 컴포넌트 사용 방법
```ts
import ScopePercentBar from '@/common/components/percentBar/ScopePercentBar';

export default function Home() {
  return (
    <ScopePercentBar
          progressivePercent={33}
          centerPercent={34}
          conservativePercent={33}
          size="small"
     />
  );
}
```
**prop 종류**
- `progressivePercent`
  - 진보 퍼센트 값
- `centerPercent`
  - 중립 퍼센트 값
- `conservativePercent`
  - 보수 퍼센트 값
- `size`
  - `small | medium | large` *medium 사이즈는 tablet 뷰에서만 지원합니다.


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| mobile |
|--|
| <img width="364" height="163" alt="스크린샷 2026-04-09 오후 3 31 07" src="https://github.com/user-attachments/assets/9a935411-c5f5-4db4-9a6c-05c4ec1df211" /> | 

| tablet |
|--|
| <img width="718" height="178" alt="스크린샷 2026-04-09 오후 3 31 40" src="https://github.com/user-attachments/assets/69260c51-5b7e-4ef3-a414-c64441e708e7" /> | 

| desktop |
|--|
| <img width="864" height="163" alt="스크린샷 2026-04-09 오후 3 32 02" src="https://github.com/user-attachments/assets/e6df2500-356f-40b8-beaa-ebf53f891ca2" /> |


<img width="874" height="536" alt="스크린샷 2026-04-12 오전 5 30 52" src="https://github.com/user-attachments/assets/0d005e16-4c5d-4d94-ba91-32b4b0ccd54d" />

- 음수 및 비정상 수가 전달되면 0으로 정제합니다.
- 모든 값이 0 일때 bar를 그리지 않습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
  * 백분율 분포를 시각적으로 표시하는 새로운 컴포넌트 추가. 세 가지 범주의 비율을 표시하며, 다양한 크기와 기기별 반응형 디자인을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->