### PR TITLE
[Feat] ArticlePreviewItem 컴포넌트 구현

### DIFF
--- a/src/shared/components/articlePreviewItem/ArticlePreviewItem.tsx
+++ b/src/shared/components/articlePreviewItem/ArticlePreviewItem.tsx
@@ -49,7 +49,7 @@ const ArticlePreviewItem = ({
       <div className={styles.articleContentWrapper({ renderType })}>
         <div className={styles.metaRow}>
           <span className={styles.metaRowText}>{mediaName}</span>
-          {renderType === 'expanded' && (
+          {renderType === 'expanded' && articlePublishedDate && (
             <>
               <span className={styles.metaRowText}>•</span>
               <span className={styles.metaRowText}>{articlePublishedDate}</span>
@@ -57,7 +57,9 @@ const ArticlePreviewItem = ({
           )}
         </div>
         <p className={styles.articleTitle({ renderType })}>{articleTitle}</p>
-        {renderType === 'expanded' && <p className={styles.articleSummary}>{articleSummary}</p>}
+        {renderType === 'expanded' && articleSummary && (
+          <p className={styles.articleSummary}>{articleSummary}</p>
+        )}
       </div>
       <div className={styles.ideologyIndicatorWrapper}>
         <IdeologyIndicator

--- a/src/shared/components/articlePreviewItem/ArticlePreviewItem.tsx
+++ b/src/shared/components/articlePreviewItem/ArticlePreviewItem.tsx
@@ -13,6 +13,7 @@ interface ArticlePreviewItemPropTypes {
   articleTitle: string;
   articleSummary?: string; // 선택적 속성 (expanded 타입에만 사용)
   ideologyIndicatorValue: IdeologyIndicatorValueTypes;
+  onArticleClick: (articleId: number) => void;
 }
 
 /**
@@ -35,9 +36,10 @@ const ArticlePreviewItem = ({
   articleTitle,
   articleSummary,
   ideologyIndicatorValue,
+  onArticleClick,
 }: ArticlePreviewItemPropTypes) => {
   const handleClickArticle = () => {
-    console.log('[ArticlePreviewItem] 기사 상세 페이지로 이동 예정', { articleId });
+    onArticleClick(articleId);
   };
 
   return (

--- a/src/shared/components/articlePreviewItem/ArticlePreviewItem.tsx
+++ b/src/shared/components/articlePreviewItem/ArticlePreviewItem.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import * as styles from './articlePreviewItem.css';
+import { type IdeologyIndicatorValueTypes } from '@/common/components/indicator/constants';
+import IdeologyIndicator from '@/common/components/indicator/IdeologyIndicator';
+import { type IdeologyIndicatorResponsiveSizeTypes } from '@/common/components/indicator/types';
+
+interface ArticlePreviewItemPropTypes {
+  renderType: 'default' | 'compact' | 'expanded'; // default(언론사명, 제목, 지표) / compact(default와 동일, 좁은 영역용) / expanded(언론사명, 날짜, 제목, 요약, 지표)
+  articleId: number;
+  mediaName: string;
+  articlePublishedDate?: string; // 선택적 속성 (expanded 타입에만 사용)
+  articleTitle: string;
+  articleSummary?: string; // 선택적 속성 (expanded 타입에만 사용)
+  ideologyIndicatorValue: IdeologyIndicatorValueTypes;
+}
+
+/**
+ * @description 기사 미리보기 아이템 컴포넌트에서 사용하는 기사 성향 아이콘 사이즈 매핑
+ */
+const IDEOLOGY_INDICATOR_SIZE_BY_RENDER_TYPE: Record<
+  ArticlePreviewItemPropTypes['renderType'],
+  IdeologyIndicatorResponsiveSizeTypes
+> = {
+  default: { desktop: 'medium', tablet: 'medium', mobile: 'medium' },
+  compact: { desktop: 'small', tablet: 'small', mobile: 'extraSmall' },
+  expanded: { desktop: 'medium', tablet: 'medium', mobile: 'medium' },
+};
+
+const ArticlePreviewItem = ({
+  renderType,
+  articleId,
+  mediaName,
+  articlePublishedDate,
+  articleTitle,
+  articleSummary,
+  ideologyIndicatorValue,
+}: ArticlePreviewItemPropTypes) => {
+  const handleClickArticle = () => {
+    console.log('[ArticlePreviewItem] 기사 상세 페이지로 이동 예정', { articleId });
+  };
+
+  return (
+    <div
+      className={styles.articlePreviewWrapper({ renderType })}
+      role="button"
+      onClick={handleClickArticle}
+    >
+      <div className={styles.articleContentWrapper({ renderType })}>
+        <div className={styles.metaRow}>
+          <span className={styles.metaRowText}>{mediaName}</span>
+          {renderType === 'expanded' && (
+            <>
+              <span className={styles.metaRowText}>•</span>
+              <span className={styles.metaRowText}>{articlePublishedDate}</span>
+            </>
+          )}
+        </div>
+        <p className={styles.articleTitle({ renderType })}>{articleTitle}</p>
+        {renderType === 'expanded' && <p className={styles.articleSummary}>{articleSummary}</p>}
+      </div>
+      <div className={styles.ideologyIndicatorWrapper}>
+        <IdeologyIndicator
+          value={ideologyIndicatorValue}
+          size={IDEOLOGY_INDICATOR_SIZE_BY_RENDER_TYPE[renderType]}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ArticlePreviewItem;

--- a/src/shared/components/articlePreviewItem/articlePreviewItem.css.ts
+++ b/src/shared/components/articlePreviewItem/articlePreviewItem.css.ts
@@ -1,0 +1,178 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+import { color, typography, media } from '@/shared/styles';
+
+export const articlePreviewWrapper = recipe({
+  base: {
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    cursor: 'pointer',
+  },
+
+  variants: {
+    renderType: {
+      default: {
+        padding: '1.25rem 0.9375rem 0 0.9375rem',
+        gap: '0.5rem',
+        '@media': {
+          [media.belowDesktop]: {
+            padding: '1.25rem 0.3125rem',
+            gap: '1.25rem',
+          },
+        },
+      },
+      compact: {
+        padding: '1.25rem 1.125rem 0 1.125rem',
+        gap: '5rem',
+        '@media': {
+          [media.belowDesktop]: {
+            padding: '0',
+            gap: '0.94rem',
+          },
+        },
+      },
+      expanded: {
+        padding: '1.25rem 0.625rem 0 0.625rem',
+        gap: '0.5rem',
+      },
+    },
+  },
+
+  defaultVariants: {
+    renderType: 'default',
+  },
+});
+
+export const articleContentWrapper = recipe({
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+  },
+  variants: {
+    renderType: {
+      default: {
+        '@media': {
+          [media.belowDesktop]: {
+            gap: '0.25rem',
+          },
+        },
+      },
+      compact: {
+        '@media': {
+          [media.belowDesktop]: {
+            gap: '0.25rem',
+          },
+        },
+      },
+      expanded: {},
+    },
+  },
+
+  defaultVariants: {
+    renderType: 'default',
+  },
+});
+
+export const metaRow = style({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: '0.3125rem',
+});
+
+export const metaRowText = style({
+  ...typography.desktop.body3,
+  color: color.text.tertiary,
+  '@media': {
+    [media.tablet]: {
+      ...typography.tablet.body3,
+    },
+    [media.mobile]: {
+      ...typography.phone.body3,
+    },
+  },
+});
+
+export const articleTitle = recipe({
+  base: {
+    color: color.text.main,
+    display: '-webkit-box',
+    WebkitBoxOrient: 'vertical',
+    overflow: 'hidden',
+    WebkitLineClamp: 3,
+  },
+
+  variants: {
+    renderType: {
+      default: {
+        ...typography.correction,
+        ...typography.desktop.h4,
+        WebkitLineClamp: 2,
+        '@media': {
+          [media.tablet]: {
+            ...typography.tablet.h4,
+            WebkitLineClamp: 3,
+          },
+          [media.mobile]: {
+            ...typography.phone.h3,
+            WebkitLineClamp: 3,
+          },
+        },
+      },
+      compact: {
+        ...typography.desktop.h4,
+        '@media': {
+          [media.tablet]: {
+            ...typography.tablet.body2,
+          },
+          [media.mobile]: {
+            ...typography.phone.body2,
+          },
+        },
+      },
+      expanded: {
+        ...typography.correction,
+        ...typography.desktop.h3,
+        WebkitLineClamp: 2,
+        '@media': {
+          [media.tablet]: {
+            ...typography.tablet.h4,
+            WebkitLineClamp: 2,
+          },
+          [media.mobile]: {
+            ...typography.phone.h3,
+            WebkitLineClamp: 2,
+          },
+        },
+      },
+    },
+  },
+
+  defaultVariants: {
+    renderType: 'default',
+  },
+});
+
+export const articleSummary = style({
+  ...typography.correction,
+  ...typography.desktop.body3,
+  color: color.text.tertiary,
+  display: '-webkit-box',
+  WebkitBoxOrient: 'vertical',
+  WebkitLineClamp: 3,
+  overflow: 'hidden',
+  '@media': {
+    [media.tablet]: {
+      ...typography.tablet.body3,
+    },
+    [media.mobile]: {
+      ...typography.phone.body3,
+    },
+  },
+});
+
+export const ideologyIndicatorWrapper = style({
+  padding: '0 0.125rem',
+});

--- a/src/shared/styles/global.css.ts
+++ b/src/shared/styles/global.css.ts
@@ -2,6 +2,8 @@
 
 import { globalStyle } from '@vanilla-extract/css';
 
+import { color } from './color.css';
+
 /* Set default box-sizing */
 globalStyle('*, *::before, *::after', {
   boxSizing: 'border-box',
@@ -14,6 +16,7 @@ globalStyle('html', {
 
 /* body 스타일 */
 globalStyle('body', {
+  backgroundColor: color.brand.background,
   position: 'relative',
   minHeight: '100dvh',
   fontFamily: `var(--font-pretendard), -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif`,
@@ -67,6 +70,6 @@ globalStyle('input, textarea', {
 
 /* 접근성을 위한 기본 포커스 스타일 - 추후 커스터마이징 필요 */
 globalStyle('input:focus-visible, textarea:focus-visible', {
-  outline: '1px solid #767676',
+  outline: `1px solid ${color.text.tertiary}`,
   outlineOffset: '1px',
 });

--- a/src/shared/styles/media.ts
+++ b/src/shared/styles/media.ts
@@ -6,5 +6,6 @@ export const breakpoints = {
 export const media = {
   mobile: `screen and (max-width: ${breakpoints.mobile}px)`,
   tablet: `screen and (min-width: ${breakpoints.mobile + 1}px) and (max-width: ${breakpoints.tablet}px)`,
+  belowDesktop: `screen and (max-width: ${breakpoints.tablet}px)`,
   desktop: `screen and (min-width: ${breakpoints.tablet + 1}px)`,
 } as const;


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #35 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- 공통 미디어 쿼리 상수에 `belowDesktop` 추가
- `ArticlePreviewItem` 공유 컴포넌트 구현
  - `renderType`(`default | compact | expanded`)에 따라 기사 미리보기 UI가 분기되도록 구성

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
### 공통 미디어 쿼리 belowDesktop 추가
- 모바일과 태블릿에 동일한 스타일을 적용해야 하는 경우를 위해 `media.belowDesktop` 쿼리를 추가했습니다.
- 기존 `media.mobile`, `media.tablet`처럼 공통 스타일 분기 시 가져와 사용할 수 있습니다.

### ArticlePreviewItem 컴포넌트 사용방법

```ts
import ArticlePreviewItem from '@/shared/components/articlePreviewItem/ArticlePreviewItem';

export default function Home() {
  return (
    <div>
      <ArticlePreviewItem
        renderType="expanded"
        articleId={1}
        mediaName="언론사명"
        articlePublishedDate="2026.00.00"
        articleTitle="해당 섹션은 기사의 제목을 작성하는 섹션입니다. 세 줄 초과의 경우, 말줄임표 적용해주세요 "
        articleSummary="해당 섹션은 기사의 요약 부분입니다. “아티클_링크” 페이지 내 요약을 최대 세 줄까지 노출합니다. 세 줄 초과의 경우, 말줄임표를 적용해주세요. 다음은 주제 키워드에 대해 각 성향의 기사들이 어떤 식으로 서술하고 있는지 기사 성향을 설명하는 내용입니다. 예를 들어 “진보 성향으로 서술된 기사의 경우, 주제 키워드에 대해 ~식으로 묘사하고 있는 반면 보수 성향 기사는 ~식으로 표현하고 있습니다. 독자는 각기 다른 주제 키워드에 대한 책임 소재에 유의하길 바랍니다.”와 같이 주제 키워드에 대해 각 기사들이 어떻게 표현하고 있는지 묘사합니다."
        ideologyIndicatorValue="SL"
        onArticleClick={(articleId) => {
          console.log('기사 상세 페이지로 이동 예정', { articleId });
        }}
      />
    </div>

   <div>
      <ArticlePreviewItem
        renderType="compact" // or "default"
        articleId={1}
        mediaName="언론사명"
        articleTitle="해당 섹션은 기사의 제목을 작성하는 섹션입니다. 세 줄 초과의 경우, 말줄임표 적용해주세요 "
        ideologyIndicatorValue="SL"
        onArticleClick={(articleId) => {
          console.log('기사 상세 페이지로 이동 예정', { articleId });
        }}
      />
    </div>
  );
}

```

**renderType: `default | compact | expanded`**
- `default`: 언론사명, 제목, 성향 지표
- `compact`: default와 유사하되 좁은 영역용 타이포·패딩·지표 크기(extraSmall 등)
- `expanded`: 언론사명, 발행일, 제목, 요약, 성향 지표

**props**
> (필수) 
- articleId: 기사 고유 ID
- mediaName: 언론사명
- articleTitle: 기사 제목
- ideologyIndicatorValue: 이념 지표 표시를 위한 값
- onArticleClick: 아티클 클릭 이벤트

> (선택: expanded 타입을 위한 prop)
- articlePublishedDate: 기사 발행일
- articleSummary: 기사 요약 텍스트



## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| compact | default | expanded |
|--|--|--|
|<img width="165" height="126" alt="스크린샷 2026-04-12 오후 5 08 41" src="https://github.com/user-attachments/assets/4451a4c5-8eb5-4255-90f5-4272acb85cae" /> | <img width="386" height="146" alt="스크린샷 2026-04-12 오후 5 09 39" src="https://github.com/user-attachments/assets/e4ec26f8-19bb-46c3-935c-cf9d4608bad3" /> | <img width="672" height="175" alt="스크린샷 2026-04-12 오후 5 10 35" src="https://github.com/user-attachments/assets/838dafb2-14e8-4389-bebf-7d853589a452" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 기사 미리보기 컴포넌트 추가: 기본·컴팩트·확대 3가지 렌더 타입 지원
  * 메타 정보 표시: 매체명 항상 표시, 확대 타입에서 게시일과 구분점 표시
  * 내용 표시: 제목은 모든 타입에서 렌더, 확대 타입에서 요약 선택적 표시
  * 이념 인디케이터 추가: 렌더 타입별 크기 조절
  * 상호작용: 항목 클릭으로 기사 상세 페이지로 이동

* **스타일**
  * 반응형 스타일 및 레이아웃 레시피 추가: 모바일/태블릿/데스크톱 최적화
  * 새로운 미디어쿼리 belowDesktop 추가
  * 글로벌 스타일 업데이트: 바디 배경색 설정 및 포커스 아웃라인 색상 변경
<!-- end of auto-generated comment: release notes by coderabbit.ai -->