### PR TITLE
[Feat] ByIdeologyHeader 컴포넌트 구현

### DIFF
--- a/src/app/(home)/components/ByIdeologySection/ByIdeologyHeader/ByIdeologyHeader.tsx
+++ b/src/app/(home)/components/ByIdeologySection/ByIdeologyHeader/ByIdeologyHeader.tsx
@@ -1,0 +1,32 @@
+import * as styles from './byIdeologyHeader.css';
+import { color } from '@/shared/styles/color.css';
+
+interface ByIdeologyHeaderPropTypes {
+  ideology: 'progressive' | 'center' | 'conservative';
+}
+
+const IDEOLOGY_MAPPING_TITLE = {
+  progressive: '진보 성향 기사',
+  center: '중도 성향 기사',
+  conservative: '보수 성향 기사',
+} as const;
+
+const IDEOLOGY_COLOR_THEME = {
+  progressive: color.brand.progressive,
+  center: color.brand.center,
+  conservative: color.brand.conservative,
+} as const;
+
+const ByIdeologyHeader = ({ ideology }: ByIdeologyHeaderPropTypes) => {
+  const headerColor = IDEOLOGY_COLOR_THEME[ideology] ?? IDEOLOGY_COLOR_THEME.center;
+
+  return (
+    <div className={styles.container} style={{ backgroundColor: headerColor }}>
+      <p className={styles.title}>
+        {IDEOLOGY_MAPPING_TITLE[ideology] ?? IDEOLOGY_MAPPING_TITLE.center}
+      </p>
+    </div>
+  );
+};
+
+export default ByIdeologyHeader;

--- a/src/app/(home)/components/ByIdeologySection/ByIdeologyHeader/byIdeologyHeader.css.ts
+++ b/src/app/(home)/components/ByIdeologySection/ByIdeologyHeader/byIdeologyHeader.css.ts
@@ -1,0 +1,21 @@
+import { style } from '@vanilla-extract/css';
+import { color, typography, media } from '@/shared/styles';
+
+export const container = style({
+  width: '100%',
+  padding: '0.625rem 0 0.625rem 0.9375rem',
+});
+
+export const title = style({
+  ...typography.correction,
+  ...typography.desktop.h3,
+  color: color.brand.background,
+  '@media': {
+    [media.tablet]: {
+      ...typography.tablet.h3,
+    },
+    [media.mobile]: {
+      ...typography.phone.h3,
+    },
+  },
+});


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #38 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- ByIdeologyHeader 컴포넌트 생성
- 이념(ideology) 값에 따라 헤더 배경 색상 분기 처리

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
### ByIdeologyHeader 컴포넌트 사용 방법
```ts
import ByIdeologyHeader from './components/ByIdeologySection/ByIdeologyHeader/ByIdeologyHeader';
import * as styles from './page.css';

export default function Home() {
  return (
    <div className={styles.container}>
      <ByIdeologyHeader ideology="progressive" />
      <ByIdeologyHeader ideology="center" />
      <ByIdeologyHeader ideology="conservative" />
    </div>
  );
}
```

**prop**
- ideology
  - `'progressive' | 'center' | 'conservative'`
  - 이념 값을 기준으로 헤더 배경 색상이 분기됨

## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| Desktop | Tablet | Mobile |
|--|--|--|
| <img width="1440" height="214" alt="스크린샷 2026-04-12 오후 11 22 08" src="https://github.com/user-attachments/assets/0ec140a0-c7e8-45bb-b181-6275aa0d387b" /> | <img width="491" height="74" alt="스크린샷 2026-04-12 오후 11 21 37" src="https://github.com/user-attachments/assets/cc999e82-0d98-454d-a949-14cf9a06a68c" /> | <img width="331" height="157" alt="스크린샷 2026-04-12 오후 11 20 18" src="https://github.com/user-attachments/assets/fd0732cc-bb97-4ca3-bd70-cf3def9014a5" /> |




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 이념별(진보, 중도, 보수) 헤더 컴포넌트 추가
* 각 이념에 맞춘 테마 색상 및 제목 적용
* 태블릿 및 모바일 환경을 포함한 반응형 스타일 지원
* 예기치 않은 값에 대한 기본 중도 테마 폴백 기능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->