### PR TITLE
[Feat] FilterTabs 컴포넌트 구현

### DIFF
--- a/src/app/(home)/components/scopeCarousel/scopeCarousel.css.ts
+++ b/src/app/(home)/components/scopeCarousel/scopeCarousel.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 import { media } from '@/shared/styles';
 
 export const container = style({
-  width: '53.4375rem',
+  width: '52.8125rem',
   display: 'flex',
   flexDirection: 'column',
   gap: '0.9375rem',

--- a/src/app/(home)/constants/index.ts
+++ b/src/app/(home)/constants/index.ts
@@ -21,6 +21,7 @@ export const SECTION_TITLES = {
  * FilterTabs 카테고리 상수
  */
 
+// SCOPE 섹션 내부 카테고리
 export const SCOPE_CATEGORY_TABS = [
   { key: 'all', label: '전체' },
   { key: 'politics', label: '정치' },
@@ -30,6 +31,13 @@ export const SCOPE_CATEGORY_TABS = [
   { key: 'culture', label: '문화' },
   { key: 'tech', label: '기술' },
 ] as const;
+
+// 모바일 뷰 이념별로 뉴스 모아보기(BY IDEOLOGY) 섹션 카테고리
+export const BY_IDEOLOGY_CATEGORY_TABS = [
+  { key: 'progressive', label: '진보 성향' },
+  { key: 'center', label: '중도 성향' },
+  { key: 'conservative', label: '보수 성향' },
+];
 
 // 추후 scope 아티클 세부 페이지 구현 시, 해당 상수 파일 옮기기
 export const SUMMARY_CATEGORY_TABS = [

--- a/src/app/(home)/constants/index.ts
+++ b/src/app/(home)/constants/index.ts
@@ -1,4 +1,7 @@
-/* 각 SECTION의 subtitle과 title 값 */
+/**
+ * 각 SECTION의 subtitle과 title 값
+ */
+
 export const SECTION_TITLES = {
   keyIssue: {
     subtitle: 'HOT ISSUE',
@@ -13,3 +16,24 @@ export const SECTION_TITLES = {
     title: '이념별로 뉴스 모아보기',
   },
 } as const;
+
+/**
+ * FilterTabs 카테고리 상수
+ */
+
+export const SCOPE_CATEGORY_TABS = [
+  { key: 'all', label: '전체' },
+  { key: 'politics', label: '정치' },
+  { key: 'economy', label: '경제' },
+  { key: 'society', label: '사회' },
+  { key: 'world', label: '세계' },
+  { key: 'culture', label: '문화' },
+  { key: 'tech', label: '기술' },
+] as const;
+
+// 추후 scope 아티클 세부 페이지 구현 시, 해당 상수 파일 옮기기
+export const SUMMARY_CATEGORY_TABS = [
+  { key: 'progressive', label: '진보 성향 기사 요약 보기', mobileLabel: '진보 성향' },
+  { key: 'center', label: '중도 성향 기사 요약 보기', mobileLabel: '중도 성향' },
+  { key: 'conservative', label: '보수 성향 기사 요약 보기', mobileLabel: '보수 성향' },
+] as const;

--- a/src/common/components/filterTabs/FilterTabs.tsx
+++ b/src/common/components/filterTabs/FilterTabs.tsx
@@ -5,12 +5,12 @@ interface FilterTabsPropTypes {
   tabs: readonly FilterTabItem[];
   activeKey: string;
   onChange: (id: string) => void;
-  variant?: 'scope' | 'summary';
+  variant?: 'scope' | 'summary' | 'byIdeology';
 }
 
 const FilterTabs = ({ tabs, activeKey, onChange, variant = 'scope' }: FilterTabsPropTypes) => {
   return (
-    <div className={styles.container} role="group" aria-label="필터 탭">
+    <div className={styles.container({ variant })} role="group" aria-label="필터 탭">
       {tabs.map((tab) => (
         <button
           type="button"

--- a/src/common/components/filterTabs/FilterTabs.tsx
+++ b/src/common/components/filterTabs/FilterTabs.tsx
@@ -10,12 +10,11 @@ interface FilterTabsPropTypes {
 
 const FilterTabs = ({ tabs, activeKey, onChange, variant = 'scope' }: FilterTabsPropTypes) => {
   return (
-    <div className={styles.container} role="tablist">
+    <div className={styles.container} role="group" aria-label="필터 탭">
       {tabs.map((tab) => (
         <button
           key={tab.key}
-          role="tab"
-          aria-selected={tab.key === activeKey}
+          aria-pressed={tab.key === activeKey}
           className={`${styles.tab({ variant })} ${tab.key === activeKey ? styles.activeTab : ''}`}
           onClick={() => onChange(tab.key)}
         >

--- a/src/common/components/filterTabs/FilterTabs.tsx
+++ b/src/common/components/filterTabs/FilterTabs.tsx
@@ -13,6 +13,7 @@ const FilterTabs = ({ tabs, activeKey, onChange, variant = 'scope' }: FilterTabs
     <div className={styles.container} role="group" aria-label="필터 탭">
       {tabs.map((tab) => (
         <button
+          type="button"
           key={tab.key}
           aria-pressed={tab.key === activeKey}
           className={`${styles.tab({ variant })} ${tab.key === activeKey ? styles.activeTab : ''}`}

--- a/src/common/components/filterTabs/FilterTabs.tsx
+++ b/src/common/components/filterTabs/FilterTabs.tsx
@@ -1,13 +1,8 @@
 import * as styles from './filterTabs.css';
-
-interface FilterTabItem {
-  key: string;
-  label: string;
-  mobileLabel?: string;
-}
+import type { FilterTabItem } from './types';
 
 interface FilterTabsPropTypes {
-  tabs: FilterTabItem[];
+  tabs: readonly FilterTabItem[];
   activeKey: string;
   onChange: (id: string) => void;
   variant?: 'category' | 'ideology';

--- a/src/common/components/filterTabs/FilterTabs.tsx
+++ b/src/common/components/filterTabs/FilterTabs.tsx
@@ -5,10 +5,10 @@ interface FilterTabsPropTypes {
   tabs: readonly FilterTabItem[];
   activeKey: string;
   onChange: (id: string) => void;
-  variant?: 'category' | 'ideology';
+  variant?: 'scope' | 'summary';
 }
 
-const FilterTabs = ({ tabs, activeKey, onChange, variant = 'category' }: FilterTabsPropTypes) => {
+const FilterTabs = ({ tabs, activeKey, onChange, variant = 'scope' }: FilterTabsPropTypes) => {
   return (
     <div className={styles.container} role="tablist">
       {tabs.map((tab) => (

--- a/src/common/components/filterTabs/FilterTabs.tsx
+++ b/src/common/components/filterTabs/FilterTabs.tsx
@@ -1,0 +1,40 @@
+import * as styles from './filterTabs.css';
+
+interface FilterTabItem {
+  key: string;
+  label: string;
+  mobileLabel?: string;
+}
+
+interface FilterTabsPropTypes {
+  tabs: FilterTabItem[];
+  activeKey: string;
+  onChange: (id: string) => void;
+  variant?: 'category' | 'ideology';
+}
+
+const FilterTabs = ({ tabs, activeKey, onChange, variant = 'category' }: FilterTabsPropTypes) => {
+  return (
+    <div className={styles.container} role="tablist">
+      {tabs.map((tab) => (
+        <button
+          key={tab.key}
+          role="tab"
+          aria-selected={tab.key === activeKey}
+          className={`${styles.tab({ variant })} ${tab.key === activeKey ? styles.activeTab : ''}`}
+          onClick={() => onChange(tab.key)}
+        >
+          {tab.mobileLabel && (
+            <>
+              <span className={styles.desktopLabel}>{tab.label}</span>
+              <span className={styles.mobileLabel}>{tab.mobileLabel}</span>
+            </>
+          )}
+          {!tab.mobileLabel && tab.label}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default FilterTabs;

--- a/src/common/components/filterTabs/filterTabs.css.ts
+++ b/src/common/components/filterTabs/filterTabs.css.ts
@@ -48,7 +48,7 @@ export const tab = recipe({
 
   variants: {
     variant: {
-      category: {
+      scope: {
         width: '6.5625rem',
         '@media': {
           [media.tablet]: {
@@ -60,7 +60,7 @@ export const tab = recipe({
           },
         },
       },
-      ideology: {
+      summary: {
         padding: '0.625rem 1.875rem',
         '@media': {
           [media.mobile]: {

--- a/src/common/components/filterTabs/filterTabs.css.ts
+++ b/src/common/components/filterTabs/filterTabs.css.ts
@@ -3,19 +3,37 @@ import { color } from '@/shared/styles/color.css';
 import { media, typography } from '@/shared/styles';
 import { recipe } from '@vanilla-extract/recipes';
 
-export const container = style({
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-  borderRadius: '0.5rem',
-  overflow: 'scroll',
-  backgroundColor: color.brand.gray1,
-  padding: '0.3125rem',
-  width: '52.8125rem',
+export const container = recipe({
+  base: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    borderRadius: '0.5rem',
+    overflow: 'scroll',
+    backgroundColor: color.brand.gray1,
+    padding: '0.3125rem',
+    width: '52.8125rem',
 
-  '@media': {
-    [media.belowDesktop]: {
-      width: '100%',
+    '@media': {
+      [media.belowDesktop]: {
+        width: '100%',
+      },
+    },
+  },
+  variants: {
+    variant: {
+      scope: {},
+      summary: {},
+      byIdeology: {
+        display: 'none',
+        '@media': {
+          [media.mobile]: {
+            display: 'flex',
+            padding: '0.125rem',
+            backgroundColor: color.brand.gray2, // 모바일에서만 렌더링
+          },
+        },
+      },
     },
   },
 });
@@ -65,6 +83,14 @@ export const tab = recipe({
         '@media': {
           [media.mobile]: {
             height: '2.5rem',
+          },
+        },
+      },
+      byIdeology: {
+        padding: '0.625rem 1.875rem',
+        '@media': {
+          [media.mobile]: {
+            height: '2.1875rem',
           },
         },
       },

--- a/src/common/components/filterTabs/filterTabs.css.ts
+++ b/src/common/components/filterTabs/filterTabs.css.ts
@@ -14,10 +14,7 @@ export const container = style({
   width: '52.8125rem',
 
   '@media': {
-    [media.tablet]: {
-      width: '100%',
-    },
-    [media.mobile]: {
+    [media.belowDesktop]: {
       width: '100%',
     },
   },

--- a/src/common/components/filterTabs/filterTabs.css.ts
+++ b/src/common/components/filterTabs/filterTabs.css.ts
@@ -1,0 +1,102 @@
+import { style } from '@vanilla-extract/css';
+import { color } from '@/shared/styles/color.css';
+import { media, typography } from '@/shared/styles';
+import { recipe } from '@vanilla-extract/recipes';
+
+export const container = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  borderRadius: '0.5rem',
+  overflow: 'scroll',
+  backgroundColor: color.brand.gray1,
+  padding: '0.3125rem',
+  width: '52.8125rem',
+
+  '@media': {
+    [media.tablet]: {
+      width: '100%',
+    },
+    [media.mobile]: {
+      width: '100%',
+    },
+  },
+});
+
+export const tab = recipe({
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '3.125rem',
+    padding: '0.625rem 1.25rem',
+    cursor: 'pointer',
+    border: 'none',
+    borderRadius: '0.3125rem',
+    backgroundColor: 'transparent',
+    color: color.text.tertiary,
+    ...typography.desktop.h4,
+    transition: 'all 0.15s ease-in-out',
+    whiteSpace: 'nowrap',
+
+    '@media': {
+      [media.tablet]: {
+        ...typography.tablet.h4,
+      },
+      [media.mobile]: {
+        ...typography.phone.button,
+      },
+    },
+  },
+
+  variants: {
+    variant: {
+      category: {
+        width: '6.5625rem',
+        '@media': {
+          [media.tablet]: {
+            width: '5.625rem',
+          },
+          [media.mobile]: {
+            width: '3.0625rem',
+            height: '2.1875rem',
+          },
+        },
+      },
+      ideology: {
+        padding: '0.625rem 1.875rem',
+        '@media': {
+          [media.mobile]: {
+            height: '2.5rem',
+          },
+        },
+      },
+    },
+  },
+});
+
+export const activeTab = style({
+  backgroundColor: color.brand.background,
+  color: color.text.main,
+  ...typography.desktop.h4,
+});
+
+export const desktopLabel = style({
+  display: 'block',
+
+  '@media': {
+    [media.mobile]: {
+      display: 'none',
+    },
+  },
+});
+
+export const mobileLabel = style({
+  display: 'none',
+
+  '@media': {
+    [media.mobile]: {
+      display: 'block',
+    },
+  },
+});

--- a/src/common/components/filterTabs/types.ts
+++ b/src/common/components/filterTabs/types.ts
@@ -1,0 +1,12 @@
+/**
+ * FilterTabs 컴포넌트에서 사용하는 탭 아이템
+ * @property key - 탭의 고유 식별자
+ * @property label - 데스크톱/태블릿에서 표시할 라벨
+ * @property mobileLabel - 모바일에서 표시할 짧은 라벨 (선택사항)
+ */
+
+export interface FilterTabItem {
+  key: string;
+  label: string;
+  mobileLabel?: string;
+}


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #40 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- FilterTabs 컴포넌트 구현
- variant prop으로 category / ideology 두 가지 스타일 분기
- recipe로 variant별 padding, width, height 관리
- 모바일에서 탭 레이블을 축약어로 대체하는 mobileLabel 옵션 지원 (`desktopLabel` / `mobileLabel` 클래스로 토글)
- 반응형 대응 (tablet, mobile 브레이크포인트별 크기 조정)
- activeKey 기반 활성 탭 스타일 처리

**4/16 추가구현**
- BY IDEOLOGY 이념별로 뉴스 모아보기 필터탭 추가 구현
 
#### 파일구조
```
filterTabs/
├── FilterTabs.tsx
├── filterTabs.css.ts
└── types.ts
```

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
#### FilterTabs 컴포넌트 사용 방법
**스코프 카테고리 섹션 내부 필터**
<img width="410" height="38" alt="스크린샷 2026-04-13 오후 2 32 47" src="https://github.com/user-attachments/assets/c0143f9e-5c28-488d-9da0-57b3514c5f44" />
```ts
'use client';

import { useState } from 'react';
import FilterTabs from '@/common/components/filterTabs/FilterTabs';
import { SCOPE_CATEGORY_TABS } from './constants';

export default function Home() {
  const [scopeActiveKey, setScopeActiveKey] = useState<string>('all');

  return (
      <div>
        <FilterTabs
          tabs={SCOPE_CATEGORY_TABS}
          activeKey={scopeActiveKey}
          onChange={setScopeActiveKey}
          variant="scope"
        />
      </div>
  );
}
```

<br/>

**스코프 아티클 세부 페이지 내부 이념별 요약보기 필터**
<img width="415" height="42" alt="스크린샷 2026-04-13 오후 2 33 17" src="https://github.com/user-attachments/assets/140aa090-2dc2-427d-a667-6a82d4f6080d" />
```ts
'use client';

import { useState } from 'react';
import FilterTabs from '@/common/components/filterTabs/FilterTabs';
import { SUMMARY_CATEGORY_TABS } from './constants';

export default function Home() {
  const [summaryActiveKey, setSummaryActiveKey] = useState<string>('progressive');

  return (
      <div>
        <FilterTabs
          tabs={SUMMARY_CATEGORY_TABS}
          activeKey={summaryActiveKey}
          onChange={setSummaryActiveKey}
          variant="summary"
        />
      </div>
  );
}
```

<br/>

**BY IDEOLOGY 이념별로 뉴스 모아보기 필터**
<img width="415" height="42" alt="스크린샷 2026-04-13 오후 2 33 17" src="https://github.com/user-attachments/assets/140aa090-2dc2-427d-a667-6a82d4f6080d" />
```ts
'use client';

import { useState } from 'react';
import FilterTabs from '@/common/components/filterTabs/FilterTabs';
import { BY_IDEOLOGY_CATEGORY_TABS } from './constants';

export default function Home() {
  const [ideologyActive, setIdeologyActive] = useState<string>('progressive');

  return (
      <div>
        <FilterTabs
          tabs={BY_IDEOLOGY_CATEGORY_TABS}
          activeKey={ideologyActive}
          onChange={setIdeologyActive}
          variant="byIdeology"
        />
      </div>
  );
}
```

<br/>

#### props
```ts
interface FilterTabsPropTypes {
  tabs: readonly FilterTabItem[];
  activeKey: string;
  onChange: (id: string) => void;
  variant?: 'scope' | 'summary' | 'byIdeology';
}
```
- tabs : 탭 목록
- activeKey : 현재 활성화된 탭의 key (부모 컴포넌트에서 상태 관리 필요)
- onChange : 탭 선택 시 호출되는 콜백 (부모 컴포넌트에서 상태 관리 필요)
- variant : 탭 스타일 variant. 기본값 scope
  - scope : 스코프 카테고리 섹션에 사용되는 카테고리 (정치, 사회, 경제..)
  - summary : 스코프 아티클 세부페이지에 사용되는 이념별 요약 카테고리 (진보 성향 기사 요약 보기..)
  - byIdeology : BY IDEOLOGY 이념별로 뉴스 모아보기 카테고리

> *variant는 탭의 스타일 형태를 분기하기 위한 prop으로, scope(고정 너비, 짧은 텍스트)와 summary(padding 기반 너비, 긴 텍스트), byIdeology(padding 기반 너비, 모바일 버전, 배경 색상) 세 가지를 지원합니다.

<br>

#### tabs 카테고리 상수 위치
- 현재, 필터 카테고리 상수는 모두 `(home)/constants/index.ts`에 존재합니다.
- `SUMMARY_CATEGORY_TABS`은 추후 scope 아티클 세부 페이지 구현 시 관련 폴더 내부 파일로 이동 필요합니다.
```ts
/**
 * FilterTabs 카테고리 상수
 */

export const SCOPE_CATEGORY_TABS = [
  { key: 'all', label: '전체' },
  { key: 'politics', label: '정치' },
  { key: 'economy', label: '경제' },
  { key: 'society', label: '사회' },
  { key: 'world', label: '세계' },
  { key: 'culture', label: '문화' },
  { key: 'tech', label: '기술' },
] as const;

// 모바일 뷰 이념별로 뉴스 모아보기(BY IDEOLOGY) 섹션 카테고리
export const BY_IDEOLOGY_CATEGORY_TABS = [
  { key: 'progressive', label: '진보 성향' },
  { key: 'center', label: '중도 성향' },
  { key: 'conservative', label: '보수 성향' },
];

// 추후 scope 아티클 세부 페이지 구현 시, 해당 상수 파일 옮기기
export const SUMMARY_CATEGORY_TABS = [
  { key: 'progressive', label: '진보 성향 기사 요약 보기', mobileLabel: '진보 성향' },
  { key: 'center', label: '중도 성향 기사 요약 보기', mobileLabel: '중도 성향' },
  { key: 'conservative', label: '보수 성향 기사 요약 보기', mobileLabel: '보수 성향' },
] as const;
```   

<br/>

#### FilterTabs 스타일 관련 전달사항
- desktop 뷰에서는 FilterTabs 너비를 고정값으로 지정하고 있지만, tablet/mobile 뷰에서는 부모너비의 100%를 차지하도록 설계했습니다.
- variant가 `byIdeology`인 경우, mobile 뷰에서만 렌더링될 수 있도록 다른 뷰에서는 `display: none`을 적용합니다.



## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| mobile |
|--|
| <img width="295" height="114" alt="스크린샷 2026-04-13 오후 2 52 02" src="https://github.com/user-attachments/assets/e67b0589-1b0d-4fd8-bdeb-5e3714890239" /> <img width="296" height="37" alt="스크린샷 2026-04-16 오후 2 14 26" src="https://github.com/user-attachments/assets/f74a2bed-469d-401f-a1d2-8377c2fb26dd" /> | 



| tablet |
|--|
| <img width="807" height="169" alt="스크린샷 2026-04-13 오후 2 51 31" src="https://github.com/user-attachments/assets/fea4167c-65f6-431c-9d64-c7024d93f7d9" /> | 


| desktop |
|--|
| <img width="856" height="168" alt="스크린샷 2026-04-13 오후 2 50 42" src="https://github.com/user-attachments/assets/534e99b5-8e54-4d28-aec4-f2558b401dc3" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 범위 및 요약용 필터 탭 추가 — 데스크탑/모바일 변형과 선택 가능한 탭 제공
  * 탭 레이블에 모바일 전용 레이블 지원

* **스타일**
  * 필터 탭의 반응형 스타일 및 레이아웃 추가
  * 특정 뷰포트에서 컨테이너 너비 조정

* **문서**
  * 탭 관련 상수에 설명 주석 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->