### PR TITLE
[Feat] ScopeArticleItem 컴포넌트 구현

### DIFF
--- a/src/common/components/percentBar/constants.ts
+++ b/src/common/components/percentBar/constants.ts
@@ -12,16 +12,16 @@ export const SCOPE_PERCENT_BAR_COLORS = {
 
 export const SCOPE_PERCENT_BAR_SIZE_STYLE = {
   mobile: {
-    SMALL: { width: '14.375rem', height: '0.9375rem', borderRadius: '0.1875rem' },
-    LARGE: { width: '21.875rem', height: '1.875rem', borderRadius: '0.3125rem' },
+    SMALL: { height: '0.9375rem', borderRadius: '0.1875rem' },
+    LARGE: { height: '1.875rem', borderRadius: '0.3125rem' },
   },
   tablet: {
-    SMALL: { width: '13.25rem', height: '0.9375rem', borderRadius: '0.1875rem' },
-    MEDIUM: { width: '29.9375rem', height: '0.9375rem', borderRadius: '0.1875rem' },
-    LARGE: { width: '43rem', height: '1.875rem', borderRadius: '0.3125rem' },
+    SMALL: { height: '0.9375rem', borderRadius: '0.1875rem' },
+    MEDIUM: { height: '0.9375rem', borderRadius: '0.1875rem' },
+    LARGE: { height: '1.875rem', borderRadius: '0.3125rem' },
   },
   desktop: {
-    SMALL: { width: '15.75rem', height: '0.9375rem', borderRadius: '0.1875rem' },
-    LARGE: { width: '52.8125rem', height: '1.875rem', borderRadius: '0.3125rem' },
+    SMALL: { height: '0.9375rem', borderRadius: '0.1875rem' },
+    LARGE: { height: '1.875rem', borderRadius: '0.3125rem' },
   },
 } as const;

--- a/src/common/components/percentBar/scopePercentBar.css.ts
+++ b/src/common/components/percentBar/scopePercentBar.css.ts
@@ -6,6 +6,7 @@ import { media } from '@/shared/styles';
 export const baseContainer = style({
   display: 'flex',
   overflow: 'hidden',
+  width: '100%',
 });
 
 export const containerVariants = styleVariants({

--- a/src/shared/components/scopeArticleItem/ScopeArticleItem.tsx
+++ b/src/shared/components/scopeArticleItem/ScopeArticleItem.tsx
@@ -3,10 +3,10 @@ import ScopePercentBar from '@/common/components/percentBar/ScopePercentBar';
 import { IDEOLOGY_LABELS, type IdeologyType } from './constants';
 import * as styles from './scopeArticleItem.css';
 
-export interface ScopeArticleItemPropTypes {
+interface ScopeArticleItemPropTypes {
   imageUrl: string;
   imageAlt: string;
-  title: string;
+  keyword: string;
   ideology: IdeologyType;
   progressiveCount: number;
   centerCount: number;
@@ -18,7 +18,7 @@ export interface ScopeArticleItemPropTypes {
 const ScopeArticleItem = ({
   imageUrl,
   imageAlt,
-  title,
+  keyword,
   ideology,
   progressiveCount,
   centerCount,
@@ -40,7 +40,7 @@ const ScopeArticleItem = ({
         <div className={styles.textContent({ size })}>
           <div className={styles.header}>
             <p className={styles.category({ size })}>SCOPE</p>
-            <h3 className={styles.title}>{title}</h3>
+            <h3 className={styles.title}>{keyword}</h3>
             <p className={styles.description({ size })}>{description}</p>
           </div>
 

--- a/src/shared/components/scopeArticleItem/ScopeArticleItem.tsx
+++ b/src/shared/components/scopeArticleItem/ScopeArticleItem.tsx
@@ -1,5 +1,8 @@
+'use client';
+
 import Image from 'next/image';
 import ScopePercentBar from '@/common/components/percentBar/ScopePercentBar';
+import { useMediaQuery } from '@/shared/hooks/useMediaQuery';
 import { IDEOLOGY_LABELS, type IdeologyType } from './constants';
 import * as styles from './scopeArticleItem.css';
 
@@ -26,7 +29,15 @@ const ScopeArticleItem = ({
   size = 'small',
   percentBarSize = 'small',
 }: ScopeArticleItemPropTypes) => {
-  const description = `에 대해 ${IDEOLOGY_LABELS[ideology]} 관점으로 보도된 기사가 더 많습니다.`;
+  const breakpoint = useMediaQuery();
+
+  // desktop 또는 tablet이면서 size가 large일 때만 "프레이밍한"/"성향으로", 나머지는 "보도된"/"관점으로"
+  const isLargeOnDesktopTablet =
+    breakpoint === 'desktop' || (breakpoint === 'tablet' && size === 'large');
+
+  const description = isLargeOnDesktopTablet
+    ? `에 대해 ${IDEOLOGY_LABELS[ideology]} 성향으로 프레이밍한 기사가 더 많습니다.`
+    : `에 대해 ${IDEOLOGY_LABELS[ideology]} 관점으로 보도된 기사가 더 많습니다.`;
 
   return (
     <div className={styles.container({ size })}>

--- a/src/shared/components/scopeArticleItem/ScopeArticleItem.tsx
+++ b/src/shared/components/scopeArticleItem/ScopeArticleItem.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import Image from 'next/image';
+import ScopePercentBar from '@/common/components/percentBar/ScopePercentBar';
+import { IDEOLOGY_LABELS, type IdeologyType } from './constants';
+import * as styles from './scopeArticleItem.css';
+
+export interface ScopeArticleItemPropTypes {
+  imageUrl: string;
+  imageAlt: string;
+  title: string;
+  ideology: IdeologyType;
+  progressiveCount: number;
+  centerCount: number;
+  conservativeCount: number;
+  size?: 'small' | 'large';
+  percentBarSize?: 'small' | 'medium' | 'large';
+}
+
+const ScopeArticleItem = ({
+  imageUrl,
+  imageAlt,
+  title,
+  ideology,
+  progressiveCount,
+  centerCount,
+  conservativeCount,
+  size = 'small',
+  percentBarSize = 'small',
+}: ScopeArticleItemPropTypes) => {
+  const description = `에 대해 ${IDEOLOGY_LABELS[ideology]} 관점으로 보도된 기사가 더 많습니다.`;
+
+  return (
+    <div className={styles.container({ size })}>
+      <div className={styles.contentWrapper}>
+        {/* 이미지 */}
+        <div className={styles.imageWrapper({ size })}>
+          <Image src={imageUrl} alt={imageAlt} width={192} height={160} className={styles.image} />
+        </div>
+
+        {/* 텍스트 콘텐츠 */}
+        <div className={styles.textContent({ size })}>
+          <div className={styles.header}>
+            <p className={styles.category({ size })}>SCOPE</p>
+            <h3 className={styles.title}>{title}</h3>
+            <p className={styles.description({ size })}>{description}</p>
+          </div>
+
+          {/* 퍼센트 바 */}
+          <ScopePercentBar
+            progressivePercent={progressiveCount}
+            centerPercent={centerCount}
+            conservativePercent={conservativeCount}
+            size={percentBarSize}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ScopeArticleItem;

--- a/src/shared/components/scopeArticleItem/ScopeArticleItem.tsx
+++ b/src/shared/components/scopeArticleItem/ScopeArticleItem.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Image from 'next/image';
 import ScopePercentBar from '@/common/components/percentBar/ScopePercentBar';
 import { IDEOLOGY_LABELS, type IdeologyType } from './constants';

--- a/src/shared/components/scopeArticleItem/constants.ts
+++ b/src/shared/components/scopeArticleItem/constants.ts
@@ -1,0 +1,11 @@
+/**
+ * ScopeArticleItem 컴포넌트의 상수
+ */
+
+export type IdeologyType = 'progressive' | 'center' | 'conservative';
+
+export const IDEOLOGY_LABELS: Record<IdeologyType, string> = {
+  progressive: '진보',
+  center: '중도',
+  conservative: '보수',
+} as const;

--- a/src/shared/components/scopeArticleItem/scopeArticleItem.css.ts
+++ b/src/shared/components/scopeArticleItem/scopeArticleItem.css.ts
@@ -24,7 +24,11 @@ export const container = recipe({
     size: {
       small: {}, // base 그대로
       large: {
-        padding: '1.25rem 0.625rem 1.25rem 0.3125rem',
+        '@media': {
+          [media.tablet]: {
+            padding: '1.25rem 0.625rem 1.25rem 0.3125rem',
+          },
+        },
       },
     },
   },
@@ -68,8 +72,12 @@ export const imageWrapper = recipe({
     size: {
       small: {}, // base 그대로
       large: {
-        width: '11.125rem',
-        height: '6.25rem',
+        '@media': {
+          [media.tablet]: {
+            width: '11.125rem',
+            height: '6.25rem',
+          },
+        },
       },
     },
   },
@@ -93,7 +101,11 @@ export const textContent = recipe({
     size: {
       small: {}, // base 그대로
       large: {
-        gap: '1.125rem',
+        '@media': {
+          [media.tablet]: {
+            gap: '1.125rem',
+          },
+        },
       },
     },
   },
@@ -122,7 +134,11 @@ export const category = recipe({
     size: {
       small: {}, // base 그대로
       large: {
-        ...typography.desktop.body3,
+        '@media': {
+          [media.tablet]: {
+            ...typography.desktop.body3,
+          },
+        },
       },
     },
   },
@@ -160,7 +176,11 @@ export const description = recipe({
     size: {
       small: {}, // base 그대로
       large: {
-        ...typography.desktop.caption,
+        '@media': {
+          [media.tablet]: {
+            ...typography.desktop.caption,
+          },
+        },
       },
     },
   },

--- a/src/shared/components/scopeArticleItem/scopeArticleItem.css.ts
+++ b/src/shared/components/scopeArticleItem/scopeArticleItem.css.ts
@@ -1,0 +1,167 @@
+import { style } from '@vanilla-extract/css';
+import { color } from '@/shared/styles/color.css';
+import { media, typography } from '@/shared/styles';
+import { recipe } from '@vanilla-extract/recipes';
+
+export const container = recipe({
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    padding: '0.625rem 0',
+    width: '100%',
+    minWidth: '21.875rem',
+
+    '@media': {
+      [media.tablet]: {
+        padding: '1.25rem 1.25rem 1.5625rem 0.3125rem',
+      },
+      [media.mobile]: {
+        padding: '0.625rem 0 1.25rem 0',
+      },
+    },
+  },
+  variants: {
+    size: {
+      small: {}, // base 그대로
+      large: {
+        padding: '1.25rem 0.625rem 1.25rem 0.3125rem',
+      },
+    },
+  },
+});
+
+export const contentWrapper = style({
+  display: 'flex',
+  gap: '0.9375rem',
+
+  '@media': {
+    [media.tablet]: {
+      gap: '0.625rem',
+    },
+    [media.mobile]: {
+      gap: '0.9375rem',
+    },
+  },
+});
+
+export const imageWrapper = recipe({
+  base: {
+    flexShrink: 0,
+    width: '7rem',
+    height: '5.625rem',
+    borderRadius: '0.1875rem',
+    overflow: 'hidden',
+    backgroundColor: color.brand.gray2,
+
+    '@media': {
+      [media.tablet]: {
+        width: '6.25rem',
+        height: '5rem',
+      },
+      [media.mobile]: {
+        width: '6.25rem',
+        height: '5rem',
+      },
+    },
+  },
+  variants: {
+    size: {
+      small: {}, // base 그대로
+      large: {
+        width: '11.125rem',
+        height: '6.25rem',
+      },
+    },
+  },
+});
+
+export const image = style({
+  width: '100%',
+  height: '100%',
+  objectFit: 'cover',
+});
+
+export const textContent = recipe({
+  base: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    gap: '0.625rem',
+  },
+  variants: {
+    size: {
+      small: {}, // base 그대로
+      large: {
+        gap: '1.125rem',
+      },
+    },
+  },
+});
+
+export const header = style({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+export const category = recipe({
+  base: {
+    ...typography.desktop.body3,
+    color: color.text.tertiary,
+
+    '@media': {
+      [media.tablet]: {
+        ...typography.tablet.body3,
+      },
+      [media.mobile]: {
+        ...typography.phone.body3,
+      },
+    },
+  },
+  variants: {
+    size: {
+      small: {}, // base 그대로
+      large: {
+        ...typography.desktop.body3,
+      },
+    },
+  },
+});
+
+export const title = style({
+  ...typography.desktop.h4,
+  color: color.text.main,
+
+  '@media': {
+    [media.tablet]: {
+      ...typography.tablet.h4,
+    },
+    [media.mobile]: {
+      ...typography.phone.h3,
+    },
+  },
+});
+
+export const description = recipe({
+  base: {
+    ...typography.desktop.caption,
+    color: color.text.tertiary,
+
+    '@media': {
+      [media.tablet]: {
+        ...typography.tablet.caption,
+      },
+      [media.mobile]: {
+        ...typography.phone.caption,
+      },
+    },
+  },
+  variants: {
+    size: {
+      small: {}, // base 그대로
+      large: {
+        ...typography.desktop.caption,
+      },
+    },
+  },
+});

--- a/src/shared/hooks/useMediaQuery.ts
+++ b/src/shared/hooks/useMediaQuery.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { breakpoints } from '@/shared/styles/media';
+
+export type Breakpoint = 'mobile' | 'tablet' | 'desktop';
+
+/**
+ * 현재 브라우저의 viewport 크기에 따라 breakpoint를 감지하는 hook
+ * @returns 현재 breakpoint ('mobile' | 'tablet' | 'desktop')
+ *
+ * @example
+ * const breakpoint = useMediaQuery();
+ * if (breakpoint === 'mobile') {
+ *   // 모바일 전용 로직
+ * }
+ */
+export const useMediaQuery = (): Breakpoint => {
+  // 서버 사이드 렌더링 초기값: 'desktop'
+  // 클라이언트에서 useEffect에서 실제 값으로 업데이트됨
+  const [breakpoint, setBreakpoint] = useState<Breakpoint>('desktop');
+
+  useEffect(() => {
+    const updateBreakpoint = () => {
+      const width = window.innerWidth;
+
+      if (width <= breakpoints.mobile) {
+        setBreakpoint('mobile');
+      } else if (width <= breakpoints.tablet) {
+        setBreakpoint('tablet');
+      } else {
+        setBreakpoint('desktop');
+      }
+    };
+
+    // 마운트 시 초기값 계산
+    updateBreakpoint();
+
+    // 창 크기 변경 시 breakpoint 재계산
+    window.addEventListener('resize', updateBreakpoint);
+
+    // 클린업: 언마운트 시 이벤트 리스너 제거
+    return () => {
+      window.removeEventListener('resize', updateBreakpoint);
+    };
+  }, []);
+
+  return breakpoint;
+};


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #42 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- ScopeArticleItem 컴포넌트 구현
- ideology prop으로 description 텍스트 생성 — `에 대해 ${ideology} 관점으로 보도된 기사가 더 많습니다.`
- size variant(small / large)로 이미지, 텍스트, 간격 등 스타일 분기
- large는 tablet 뷰에서 사용되며, tablet에서도 desktop 타이포그래피를 유지해야 하는 요소(category, description)를 recipe로 override
- useMediaQuery 훅을 구현 및 ScopeArticleItem에 적용

#### 파일 구조
```
scopeArticleItem/
├── ScopeArticleItem.tsx
├── scopeArticleItem.css.ts
└── constants.ts
```


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
#### ScopeArticleItem 사용 방법
```ts
'use client';

import ScopeArticleItem from '@/shared/components/scopeArticleItem/ScopeArticleItem';

export default function Home() {
  return (
    <div>
        <ScopeArticleItem
          imageUrl="https://i.pinimg.com/736x/44/b0/f0/44b0f0315ece65cdc3b64130c91ea009.jpg"
          imageAlt="정치 관련 기사"
          keyword="주제 키워드"
          progressiveCount={8}
          centerCount={4}
          conservativeCount={2}
          ideology="progressive"
          size="large"                       // 아이템 자체 사이즈, tablet 뷰에서만 large 사용 - 나머지는 모두 small
          percentBarSize="small"
        />
    </div>
  );
}

```
#### props
```ts
interface ScopeArticleItemPropTypes {
  imageUrl: string;
  imageAlt: string;
  keyword: string;
  ideology: IdeologyType;
  progressiveCount: number;
  centerCount: number;
  conservativeCount: number;
  size?: 'small' | 'large';
  percentBarSize?: 'small' | 'medium' | 'large';
}
```
- imageUrl : 썸네일 이미지 URL
- imageAlt : 이미지 alt 텍스트
- keyword : 주제 키워드
- ideology : 해당 키워드의 주 이념 (`'progressive' | 'center' | 'conservative'`) *백엔드에서 해당 정보 넘겨줘야함
- progressiveCount : 진보 퍼센트 값
- centerCount : 중도 퍼센트 값
- conservativeCount : 보수 퍼센트 값
- size : `'small' | 'large'` 중 택 1(선택사항, 기본 디폴트값 small) *테블릿 뷰에서만 large 사이즈가 사용
- percentBarSize : 퍼센트바 사이즈 `'small' | 'medium' | 'large'`

#### useMediaQuery hook 사용방법
```ts
import { useMediaQuery } from '@/shared/hooks/useMediaQuery';

const breakpoint = useMediaQuery();
// 'mobile' | 'tablet' | 'desktop' 반환

// breakpoint 분기 예시
if (breakpoint === 'tablet') { ... }

// size prop 분기 예시 (부모 컴포넌트)
const size = breakpoint === 'tablet' ? 'large' : 'small';
<ScopeArticleItem size={size} ... />
```
- 브라우저 viewport 너비를 감지해 현재 breakpoint(`mobile | tablet | desktop`)를 반환하는 훅
- SSR 초기값이 'desktop'으로 고정되어 있어, tablet/mobile 사용자는 hydration 이후 레이아웃이 한 번 변경됩니다. 깜빡임이 문제가 되는 경우 초기값을 null로 변경하는 방향으로 개선이 필요합니다.


#### large size 관련 전달사항
- 모든 뷰에서 기본으로 small size를 사용합니다. (prop size 디폴트값 = small)
- tablet 뷰에서 특정 구역에 large size 사용을 원할 때, 아래와 같이 tablet 브레이크포인트 조건부 스타일링이 필요합니다.
```ts
'use client';

import { useMediaQuery } from '@/shared/hooks/useMediaQuery';

const breakpoint = useMediaQuery();
const isTablet = breakpoint === 'tablet';

<ScopeArticleItem size={isTablet ? 'large' : 'small'} ... />
```

#### 컴포넌트 너비 관련 변경사항
- ScopePercentBar와 ScopeArticleItem 모두 컴포넌트 너비 고정값을 없애고 `width: 100%`로 변경했습니다.
  - 아이템 컴포넌트는 내부 레이아웃만 책임지고, 외부 크기는 전부 부모에게 위임하는 것이 재사용성과 유지보수 면에서 깔끔하다고 판단하여 수정했습니다.
- ScopeArticleItem mobile 뷰에서의 아이템 최소 너비(350px)를 minWidth로 지정하여 레이아웃 깨짐을 방지했습니다.



## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| mobile |
|--|
| <img width="301" height="90" alt="스크린샷 2026-04-13 오후 10 24 31" src="https://github.com/user-attachments/assets/52086ca0-3686-4474-ba7d-660dca797a37" /> | 


| tablet |
|--|
| <img width="791" height="328" alt="스크린샷 2026-04-13 오후 10 24 04" src="https://github.com/user-attachments/assets/3550ca7b-34ea-4521-82f3-6bd23f5886b3" /> | 
*아래가 large size


| desktop |
|--|
| <img width="781" height="123" alt="스크린샷 2026-04-13 오후 10 23 33" src="https://github.com/user-attachments/assets/9c71eb3d-6f31-44c8-a233-d991c68a4e60" /> |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 이미지, 키워드, 이데올로기 분류 및 투표 분포를 표시하는 새 아이템 컴포넌트가 추가되었습니다(소형/대형, 퍼센트바 크기 옵션 포함).
  * 반응형 브레이크포인트를 제공하는 미디어쿼리 훅이 추가되어 뷰포트에 따른 레이아웃/텍스트를 조정합니다.
  * 이데올로기 타입과 레이블 상수가 도입되었습니다.

* **UI/스타일 개선**
  * 퍼센트 바의 수평 크기 지정이 제거되어 가로 크기 유연성이 향상되었고, 퍼센트 바 컨테이너가 가용 폭을 채우도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->