### PR TITLE
[Feat] HotArticleGroup 컴포넌트 구현

### DIFF
--- a/src/app/(home)/components/hotArticleSection/hotArticleGroup/HotArticleGroup.tsx
+++ b/src/app/(home)/components/hotArticleSection/hotArticleGroup/HotArticleGroup.tsx
@@ -12,15 +12,15 @@ export default function HotArticleGroup({ ideology, articleItems }: HotArticleSe
   const breakpoint = useMediaQuery();
   const isDesktop = breakpoint === 'desktop';
 
+  // 태블릿, 모바일: 한 칸만 보이게 설정하기 위한 인덱스 관리 (0부터 시작)
   const [currentIndex, setCurrentIndex] = useState(0);
 
+  // 태블릿, 모바일: 한 칸만 보이게 설정하기 위한 타이머 설정
   useEffect(() => {
     if (isDesktop || articleItems.length <= 1) return;
-
     const timer = setInterval(() => {
       setCurrentIndex((prev) => (prev + 1) % articleItems.length);
-    }, 3000);
-
+    }, 4000);
     return () => clearInterval(timer);
   }, [isDesktop, articleItems.length]);
 

--- a/src/app/(home)/components/hotArticleSection/hotArticleGroup/HotArticleGroup.tsx
+++ b/src/app/(home)/components/hotArticleSection/hotArticleGroup/HotArticleGroup.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import ArticlePreviewItem from '@/shared/components/articlePreviewItem/ArticlePreviewItem';
+import * as styles from './hotArticleGroup.css';
+
+import { useMediaQuery } from '@/shared/hooks/useMediaQuery';
+import { type HotArticleSectionGroupTypes } from '@/app/(home)/types/hotArticleSection';
+
+export default function HotArticleGroup({ ideology, articleItems }: HotArticleSectionGroupTypes) {
+  // 미디어 쿼리 확인 후 데스크탑 여부 확인
+  const breakpoint = useMediaQuery();
+  const isDesktop = breakpoint === 'desktop';
+
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  useEffect(() => {
+    if (isDesktop || articleItems.length <= 1) return;
+
+    const timer = setInterval(() => {
+      setCurrentIndex((prev) => (prev + 1) % articleItems.length);
+    }, 3000);
+
+    return () => clearInterval(timer);
+  }, [isDesktop, articleItems.length]);
+
+  const currentArticle = articleItems[currentIndex];
+
+  return (
+    <div className={styles.group}>
+      <div className={styles.ideologyLabel({ ideology })}>
+        {ideology === 'progressive' ? '진보 독자' : '보수 독자'}
+      </div>
+
+      {/* desktop only */}
+      <h2 className={styles.desktopGroupTitle}>관심 기사</h2>
+
+      {isDesktop ? (
+        // desktop only
+        <div className={styles.list}>
+          {articleItems.map((article) => (
+            <div key={article.articleId} className={styles.desktopArticleItem}>
+              <ArticlePreviewItem {...article} renderType="compact" />
+            </div>
+          ))}
+        </div>
+      ) : (
+        // tablet, mobile only
+        currentArticle && (
+          <div key={currentArticle.articleId} className={styles.belowDesktopArticleItem}>
+            <ArticlePreviewItem {...currentArticle} renderType="compact" />
+          </div>
+        )
+      )}
+    </div>
+  );
+}

--- a/src/app/(home)/components/hotArticleSection/hotArticleGroup/hotArticleGroup.css.ts
+++ b/src/app/(home)/components/hotArticleSection/hotArticleGroup/hotArticleGroup.css.ts
@@ -16,6 +16,7 @@ const belowDesktopArticleAnimation = keyframes({
 
 export const group = style({
   width: '100%',
+  minWidth: '12.125rem',
   maxWidth: '25.69rem',
   display: 'flex',
   flexDirection: 'column',
@@ -28,6 +29,7 @@ export const group = style({
     },
     [media.belowDesktop]: {
       padding: '0',
+      minWidth: '9.8125rem',
     },
     [media.tablet]: {
       maxWidth: '23.625rem',

--- a/src/app/(home)/components/hotArticleSection/hotArticleGroup/hotArticleGroup.css.ts
+++ b/src/app/(home)/components/hotArticleSection/hotArticleGroup/hotArticleGroup.css.ts
@@ -1,6 +1,18 @@
-import { style } from '@vanilla-extract/css';
+import { keyframes, style } from '@vanilla-extract/css';
 import { color, media, typography } from '@/shared/styles';
 import { recipe } from '@vanilla-extract/recipes';
+
+/** 태블릿, 모바일: 짧은 페이드 + 아주 작은 Y 이동 애니메이션 */
+const belowDesktopArticleAnimation = keyframes({
+  '0%': {
+    transform: 'translateY(0.375rem)',
+    opacity: 0,
+  },
+  '100%': {
+    transform: 'translateY(0)',
+    opacity: 1,
+  },
+});
 
 export const group = style({
   width: '100%',
@@ -87,6 +99,7 @@ export const belowDesktopArticleItem = style({
   '@media': {
     [media.belowDesktop]: {
       marginTop: '0.62rem',
+      animation: `${belowDesktopArticleAnimation} 0.38s ease-out`,
     },
   },
 });

--- a/src/app/(home)/components/hotArticleSection/hotArticleGroup/hotArticleGroup.css.ts
+++ b/src/app/(home)/components/hotArticleSection/hotArticleGroup/hotArticleGroup.css.ts
@@ -1,0 +1,92 @@
+import { style } from '@vanilla-extract/css';
+import { color, media, typography } from '@/shared/styles';
+import { recipe } from '@vanilla-extract/recipes';
+
+export const group = style({
+  width: '100%',
+  maxWidth: '25.69rem',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+  padding: '0.94rem 1.125rem',
+  '@media': {
+    [media.desktop]: {
+      boxShadow: '0 0 2px 0 rgba(17, 17, 17, 0.20)',
+      borderRadius: '0.3125rem',
+    },
+    [media.belowDesktop]: {
+      padding: '0',
+    },
+    [media.tablet]: {
+      maxWidth: '23.625rem',
+    },
+    [media.mobile]: {
+      maxWidth: '21.875rem',
+    },
+  },
+});
+
+// 각 그룹의 기사 리스트를 표시하는 컨테이너
+export const list = style({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+// '진보 독자' 또는 '보수 독자' 라벨
+export const ideologyLabel = recipe({
+  base: {
+    ...typography.correction,
+    ...typography.desktop.h4,
+    '@media': {
+      [media.tablet]: {
+        ...typography.tablet.h4,
+      },
+      [media.mobile]: {
+        ...typography.phone.h3,
+      },
+    },
+  },
+  variants: {
+    ideology: {
+      progressive: {
+        color: color.brand.progressive,
+      },
+      conservative: {
+        color: color.brand.conservative,
+      },
+    },
+  },
+  defaultVariants: {
+    ideology: 'progressive',
+  },
+});
+
+// 데스크탑 뷰에서의 '관심 기사' 제목
+export const desktopGroupTitle = style({
+  ...typography.correction,
+  ...typography.desktop.h2,
+  color: color.text.main,
+  '@media': {
+    [media.belowDesktop]: {
+      display: 'none',
+    },
+  },
+});
+
+// 데스크탑 뷰에서의 기사 아이템
+export const desktopArticleItem = style({
+  '@media': {
+    [media.desktop]: {
+      borderBottom: `1px solid ${color.brand.gray1}`,
+    },
+  },
+});
+
+// 태블릿, 모바일 뷰에서의 기사 아이템
+export const belowDesktopArticleItem = style({
+  '@media': {
+    [media.belowDesktop]: {
+      marginTop: '0.62rem',
+    },
+  },
+});

--- a/src/app/(home)/constants/index.ts
+++ b/src/app/(home)/constants/index.ts
@@ -15,6 +15,10 @@ export const SECTION_TITLES = {
     subtitle: 'BY IDEOLOGY',
     title: '이념별로 뉴스 모아보기',
   },
+  hotArticle: {
+    subtitle: 'HOT ARTICLE',
+    title: '실시간 관심 기사',
+  },
 } as const;
 
 /**

--- a/src/app/(home)/types/hotArticleSection.ts
+++ b/src/app/(home)/types/hotArticleSection.ts
@@ -1,0 +1,8 @@
+import { type ArticleBaseTypes } from '@/shared/types/articleItemType';
+
+export type IdeologyType = 'progressive' | 'conservative';
+
+export interface HotArticleSectionGroupTypes {
+  ideology: IdeologyType;
+  articleItems: ArticleBaseTypes[];
+}

--- a/src/shared/components/articlePreviewItem/articlePreviewItem.css.ts
+++ b/src/shared/components/articlePreviewItem/articlePreviewItem.css.ts
@@ -23,7 +23,7 @@ export const articlePreviewWrapper = recipe({
         },
       },
       compact: {
-        padding: '1.25rem 1.125rem 2.19rem 1.125rem',
+        padding: '1.25rem 0 2.19rem',
         gap: '0.5rem',
         '@media': {
           [media.belowDesktop]: {


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #48 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- HotArticleGroup 컴포넌트 구현
  - 이념별(진보/보수) 기사 그룹 UI 구성
- 반응형에 따른 렌더링 분기 처리
  - desktop
    - 기사 리스트 전체 렌더링
    - 그룹 내부에 관심 기사 타이틀 노출
  - tablet / mobile
    - 기사 1개씩 순차 노출 (자동 슬라이드)
- useMediaQuery를 활용한 breakpoint 기반 UI 분기
- useEffect + setInterval을 이용한 자동 순환 로직 구현
- 기사 전환 시 애니메이션 효과 추가
- `/app/(home)/constants/index.ts`에 HotArticleSection 텍스트 상수 추가

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
### `/app/(home)/constants/index.ts `파일 상수 추가
- HotArticleSection을 위한 실시간 관심 기사 상수 추가했습니다!
```ts
  hotArticle: {
    subtitle: 'HOT ARTICLE',
    title: '실시간 관심 기사',
  },
```

### HotArticleGroup 컴포넌트 사용 방법
```ts
import HotArticleGroup from './HotArticleGroup';

<HotArticleGroup
  ideology="progressive"
  articleItems={articles}
/>
```

**Props**
- ideology
  - 'progressive' | 'conservative'
- articleItems
  - ArticlePreviewItem에 전달되는 기사 데이터 배열


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| Desktop | Tablet | Mobile |
|--|--|--|
| <img width="445" height="673" alt="스크린샷 2026-04-19 오전 9 38 55" src="https://github.com/user-attachments/assets/78e56f35-98df-4cc2-bb53-64acabe283f3" /> | <img alt="화면 기록 2026-04-19 오전 9 38 02" src="https://github.com/user-attachments/assets/09c2473b-6a69-4bf8-8143-018ee144b55b" /> | <img   alt="화면 기록 2026-04-19 오전 9 37 16" src="https://github.com/user-attachments/assets/6efd831c-6176-4ec6-a4f2-bbf9a39d312d" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 이념 기반 "실시간 관심 기사" 섹션 추가
  * 데스크톱에서는 전체 기사 목록 표시, 모바일/태블릿에서는 자동 순환 표시 기능 포함
  * 반응형 디자인으로 다양한 화면 크기 지원

* **Style**
  * 컴팩트 레이아웃 패딩 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->