### PR TITLE
[Feat] RelatedArticleSection 컴포넌트 구현

### DIFF
--- a/src/app/(main)/article/components/relatedArticleSection/RelatedArticleSection.tsx
+++ b/src/app/(main)/article/components/relatedArticleSection/RelatedArticleSection.tsx
@@ -1,0 +1,42 @@
+'use client';
+import { useState } from 'react';
+
+import * as styles from './relatedArticleSection.css';
+import RelatedArticleTabs from '../relatedArticleTabs/RelatedArticleTabs';
+import type { RelatedArticleTabValue } from '../relatedArticleTabs/constants';
+
+import ArticlePreviewItem from '@/shared/components/articlePreviewItem/ArticlePreviewItem';
+import { RELATED_ARTICLE_SECTION_DATA } from '@/mocks/data/home';
+
+const RelatedArticleSection = () => {
+  const [selectedIdeology, setSelectedIdeology] = useState<RelatedArticleTabValue>('all');
+
+  const handleIdeologyChange = (ideology: RelatedArticleTabValue) => {
+    setSelectedIdeology(ideology);
+    console.log(ideology);
+  };
+
+  const articleItems = RELATED_ARTICLE_SECTION_DATA.flatMap((item) => item.articleItems);
+  const relatedArticleCount = articleItems.length;
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.tabsContainer}>
+        <p className={styles.desktopTitle}>
+          연관기사 <span className={styles.desktopCount}>{relatedArticleCount}</span>
+        </p>
+        <p className={styles.mobileTitle}>연관 기사</p>
+        <RelatedArticleTabs activeTab={selectedIdeology} onTabChange={handleIdeologyChange} />
+      </div>
+      <div className={styles.articlesContainer}>
+        {articleItems.map((article) => (
+          <div key={article.articleId} className={styles.articleItem}>
+            <ArticlePreviewItem {...article} renderType="expanded" />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default RelatedArticleSection;

--- a/src/app/(main)/article/components/relatedArticleSection/relatedArticleSection.css.ts
+++ b/src/app/(main)/article/components/relatedArticleSection/relatedArticleSection.css.ts
@@ -1,0 +1,80 @@
+import { style } from '@vanilla-extract/css';
+import { color, media, typography } from '@/shared/styles';
+
+export const section = style({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+export const tabsContainer = style({
+  width: '100%',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  borderBottom: `0.5px solid ${color.brand.gray2}`,
+  '@media': {
+    [media.tablet]: {
+      flexDirection: 'column',
+      alignItems: 'flex-start',
+      justifyContent: 'flex-start',
+    },
+    [media.mobile]: {
+      flexDirection: 'column',
+      alignItems: 'flex-start',
+      justifyContent: 'flex-start',
+    },
+  },
+});
+
+export const desktopTitle = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.25rem',
+  color: color.text.main,
+  ...typography.desktop.h3,
+  '@media': {
+    [media.tablet]: {
+      display: 'none',
+    },
+    [media.mobile]: {
+      display: 'none',
+    },
+  },
+});
+
+export const desktopCount = style({
+  ...typography.desktop.h3,
+});
+
+export const mobileTitle = style({
+  display: 'none',
+  color: color.text.main,
+  '@media': {
+    [media.belowDesktop]: {
+      display: 'block',
+      ...typography.correction,
+      marginBottom: '0.62rem',
+    },
+    [media.tablet]: {
+      ...typography.tablet.h1,
+    },
+    [media.mobile]: {
+      ...typography.phone.h1,
+    },
+  },
+});
+
+export const articlesContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  padding: '0 0.625rem',
+});
+
+export const articleItem = style({
+  borderBottom: `1px solid ${color.brand.gray2}`,
+  // '@media': {
+  //   [media.belowDesktop]: {
+  //     marginBottom: '1.25rem',
+  //   },
+  // },
+});

--- a/src/app/(main)/article/components/relatedArticleSection/relatedArticleSection.css.ts
+++ b/src/app/(main)/article/components/relatedArticleSection/relatedArticleSection.css.ts
@@ -72,9 +72,4 @@ export const articlesContainer = style({
 
 export const articleItem = style({
   borderBottom: `1px solid ${color.brand.gray2}`,
-  // '@media': {
-  //   [media.belowDesktop]: {
-  //     marginBottom: '1.25rem',
-  //   },
-  // },
 });

--- a/src/app/(main)/article/components/relatedArticleTabs/relatedArticleTabs.css.ts
+++ b/src/app/(main)/article/components/relatedArticleTabs/relatedArticleTabs.css.ts
@@ -27,6 +27,7 @@ export const tab = recipe({
     padding: '1.03rem 0',
     cursor: 'pointer',
     border: 'none',
+    borderBottom: `3px solid transparent`,
     backgroundColor: 'transparent',
     '@media': {
       [media.tablet]: {

--- a/src/app/(main)/article/types/relatedArticleSection.ts
+++ b/src/app/(main)/article/types/relatedArticleSection.ts
@@ -1,0 +1,11 @@
+import {
+  type ArticleBaseTypes,
+  type ExpandedArticleExtraTypes,
+} from '@/shared/types/articleItemType';
+
+export type IdeologyType = 'progressive' | 'center' | 'conservative';
+
+export interface RelatedArticleSectionGroupTypes {
+  ideology: IdeologyType;
+  articleItems: (ArticleBaseTypes & ExpandedArticleExtraTypes)[];
+}

--- a/src/mocks/data/home.ts
+++ b/src/mocks/data/home.ts
@@ -3,6 +3,7 @@ import { type ScopeCarouselDataType } from '@/app/(main)/(home)/types/scopeCarou
 import type { ScopeArticleItemData } from '@/shared/components/scopeArticleItem/types';
 import { type HotArticleSectionGroupTypes } from '@/app/(main)/(home)/types/hotArticleSection';
 import { type ByIdeologySectionGroupTypes } from '@/app/(main)/(home)/types/byIdeologySection';
+import { type RelatedArticleSectionGroupTypes } from '@/app/(main)/article/types/relatedArticleSection';
 
 export const HOT_ISSUE_ARTICLE_GROUP: HotIssueGroupTypes[] = [
   {
@@ -753,6 +754,85 @@ export const BY_IDEOLOGY_SECTION_DATA: ByIdeologySectionGroupTypes[] = [
         articleTitle:
           '해당 섹션은 기사의 제목을 작성하는 섹션입니다. 세 줄 초과의 경우, 말줄임표 적용해주세요.',
         mediaName: '언론사명',
+      },
+    ],
+  },
+];
+
+// 스코프, 링크 세부 페이지 연관기사 영역 데이터
+export const RELATED_ARTICLE_SECTION_DATA: RelatedArticleSectionGroupTypes[] = [
+  {
+    ideology: 'progressive',
+    articleItems: [
+      {
+        articleId: 1,
+        ideologyIndicatorValue: 'L',
+        articleTitle:
+          '해당 섹션은 기사의 제목을 작성하는 섹션입니다. 세 줄 초과의 경우, 말줄임표 적용해주세요.',
+        mediaName: '언론사명',
+        articlePublishedDate: '2026-04-25',
+        articleSummary:
+          '해당 섹션은 기사의 요약 부분입니다. “아티클_링크” 페이지 내 요약을 최대 세 줄까지 노출합니다. 세 줄 초과의 경우, 말줄임표를 적용해주세요. 다음은 주제 키워드에 대해 각 성향의 기사들이 어떤 식으로 서술하고 있는지 기사 성향을 설명하는 내용입니다. 예를 들어 “진보 성향으로 서술된 기사의 경우, 주제 키워드에 대해 ~식으로 묘사하고 있는 반면 보수 성향 기사는 ~식으로 표현하고 있습니다. 독자는 각기 다른 주제 키워드에 대한 책임 소재에 유의하길 바랍니다.”와 같이 주제 키워드에 대해 각 기사들이 어떻게 표현하고 있는지 묘사합니다.',
+      },
+      {
+        articleId: 2,
+        ideologyIndicatorValue: 'SL',
+        articleTitle:
+          '해당 섹션은 기사의 제목을 작성하는 섹션입니다. 세 줄 초과의 경우, 말줄임표 적용해주세요.',
+        mediaName: '언론사명',
+        articlePublishedDate: '2026-04-25',
+        articleSummary:
+          '해당 섹션은 기사의 요약 부분입니다. “아티클_링크” 페이지 내 요약을 최대 세 줄까지 노출합니다. 세 줄 초과의 경우, 말줄임표를 적용해주세요. 다음은 주제 키워드에 대해 각 성향의 기사들이 어떤 식으로 서술하고 있는지 기사 성향을 설명하는 내용입니다. 예를 들어 “진보 성향으로 서술된 기사의 경우, 주제 키워드에 대해 ~식으로 묘사하고 있는 반면 보수 성향 기사는 ~식으로 표현하고 있습니다. 독자는 각기 다른 주제 키워드에 대한 책임 소재에 유의하길 바랍니다.”와 같이 주제 키워드에 대해 각 기사들이 어떻게 표현하고 있는지 묘사합니다.',
+      },
+    ],
+  },
+  {
+    ideology: 'center',
+    articleItems: [
+      {
+        articleId: 3,
+        ideologyIndicatorValue: 'C',
+        articleTitle:
+          '해당 섹션은 기사의 제목을 작성하는 섹션입니다. 세 줄 초과의 경우, 말줄임표 적용해주세요.',
+        mediaName: '언론사명',
+        articlePublishedDate: '2026-04-25',
+        articleSummary:
+          '해당 섹션은 기사의 요약 부분입니다. “아티클_링크” 페이지 내 요약을 최대 세 줄까지 노출합니다. 세 줄 초과의 경우, 말줄임표를 적용해주세요. 다음은 주제 키워드에 대해 각 성향의 기사들이 어떤 식으로 서술하고 있는지 기사 성향을 설명하는 내용입니다. 예를 들어 “진보 성향으로 서술된 기사의 경우, 주제 키워드에 대해 ~식으로 묘사하고 있는 반면 보수 성향 기사는 ~식으로 표현하고 있습니다. 독자는 각기 다른 주제 키워드에 대한 책임 소재에 유의하길 바랍니다.”와 같이 주제 키워드에 대해 각 기사들이 어떻게 표현하고 있는지 묘사합니다.',
+      },
+      {
+        articleId: 4,
+        ideologyIndicatorValue: 'C',
+        articleTitle:
+          '해당 섹션은 기사의 제목을 작성하는 섹션입니다. 세 줄 초과의 경우, 말줄임표 적용해주세요.',
+        mediaName: '언론사명',
+        articlePublishedDate: '2026-04-25',
+        articleSummary:
+          '해당 섹션은 기사의 요약 부분입니다. “아티클_링크” 페이지 내 요약을 최대 세 줄까지 노출합니다. 세 줄 초과의 경우, 말줄임표를 적용해주세요. 다음은 주제 키워드에 대해 각 성향의 기사들이 어떤 식으로 서술하고 있는지 기사 성향을 설명하는 내용입니다. 예를 들어 “진보 성향으로 서술된 기사의 경우, 주제 키워드에 대해 ~식으로 묘사하고 있는 반면 보수 성향 기사는 ~식으로 표현하고 있습니다. 독자는 각기 다른 주제 키워드에 대한 책임 소재에 유의하길 바랍니다.”와 같이 주제 키워드에 대해 각 기사들이 어떻게 표현하고 있는지 묘사합니다.',
+      },
+    ],
+  },
+  {
+    ideology: 'conservative',
+    articleItems: [
+      {
+        articleId: 5,
+        ideologyIndicatorValue: 'R',
+        articleTitle:
+          '해당 섹션은 기사의 제목을 작성하는 섹션입니다. 세 줄 초과의 경우, 말줄임표 적용해주세요.',
+        mediaName: '언론사명',
+        articlePublishedDate: '2026-04-25',
+        articleSummary:
+          '해당 섹션은 기사의 요약 부분입니다. “아티클_링크” 페이지 내 요약을 최대 세 줄까지 노출합니다. 세 줄 초과의 경우, 말줄임표를 적용해주세요. 다음은 주제 키워드에 대해 각 성향의 기사들이 어떤 식으로 서술하고 있는지 기사 성향을 설명하는 내용입니다. 예를 들어 “진보 성향으로 서술된 기사의 경우, 주제 키워드에 대해 ~식으로 묘사하고 있는 반면 보수 성향 기사는 ~식으로 표현하고 있습니다. 독자는 각기 다른 주제 키워드에 대한 책임 소재에 유의하길 바랍니다.”와 같이 주제 키워드에 대해 각 기사들이 어떻게 표현하고 있는지 묘사합니다.',
+      },
+      {
+        articleId: 6,
+        ideologyIndicatorValue: 'SR',
+        articleTitle:
+          '해당 섹션은 기사의 제목을 작성하는 섹션입니다. 세 줄 초과의 경우, 말줄임표 적용해주세요.',
+        mediaName: '언론사명',
+        articlePublishedDate: '2026-04-25',
+        articleSummary:
+          '해당 섹션은 기사의 요약 부분입니다. “아티클_링크” 페이지 내 요약을 최대 세 줄까지 노출합니다. 세 줄 초과의 경우, 말줄임표를 적용해주세요. 다음은 주제 키워드에 대해 각 성향의 기사들이 어떤 식으로 서술하고 있는지 기사 성향을 설명하는 내용입니다. 예를 들어 “진보 성향으로 서술된 기사의 경우, 주제 키워드에 대해 ~식으로 묘사하고 있는 반면 보수 성향 기사는 ~식으로 표현하고 있습니다. 독자는 각기 다른 주제 키워드에 대한 책임 소재에 유의하길 바랍니다.”와 같이 주제 키워드에 대해 각 기사들이 어떻게 표현하고 있는지 묘사합니다.',
       },
     ],
   },


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #64 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- 기사 `scope`, `link` 상세 페이지에서 사용할 연관 기사 영역 UI 구현
- 데스크톱/모바일에 맞춘 제목 레이아웃과, 이념(전체·진보·중도·보수) 필터용 RelatedArticleTabs를 조합
- ArticlePreviewItem(expanded)으로 목록을 렌더링, 목 데이터는 RELATED_ARTICLE_SECTION_DATA로 연결

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
```ts
import RelatedArticleSection from '../../components/relatedArticleSection/RelatedArticleSection';

export default function ScopeArticlePage() {
  return (
    <>
      <RelatedArticleSection />
    </>
  );
}
```

**Props**
- 별도로 전달받는 props는 없습니다.

**데이터 처리**
- API 연동은 RelatedArticleSection 컴포넌트 내부에서 처리할 예정입니다.

## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| Desktop | Tablet | Mobile |
|--|--|--|
| <img width="1348" height="666" alt="스크린샷 2026-04-27 오후 12 54 18" src="https://github.com/user-attachments/assets/648e130d-5c61-4cf1-aad1-1809a001b722" /> | <img width="448" height="601" alt="스크린샷 2026-04-27 오후 12 54 04" src="https://github.com/user-attachments/assets/bfb709ab-9828-4dac-92a4-16cb84626f05" /> | <img width="316" height="585" alt="스크린샷 2026-04-27 오후 12 53 49" src="https://github.com/user-attachments/assets/4d9ae12b-a1f4-4172-8c08-98c56de2d399" /> |
