### PR TITLE
[Feat] Title 컴포넌트 variant별 스타일 추가

### DIFF
--- a/src/common/components/title/Title.tsx
+++ b/src/common/components/title/Title.tsx
@@ -1,15 +1,23 @@
-import { subtitleStyle, titleStyle } from '@/common/components/title/title.css';
+import * as styles from './title.css';
 
+/**
+ * 타이틀 섹션 Props
+ * @property {'default' | 'articleHeader' | 'articleSummary'} variant - 레이아웃 스타일 변형
+ * - default : 기본 이념 페이지 섹션별 타이틀
+ * - articleHeader : SCOPE 기사 상세 페이지 헤더 타이틀 (SCOPE/주제키워드)
+ * - articleSummary : SCOPE 기사 상세 페이지 기사 요약 섹션 타이틀 (언론사명/기사제목)
+ */
 interface TitlePropTypes {
   subtitle: string;
   title: string;
+  variant?: 'default' | 'articleHeader' | 'articleSummary';
 }
 
-const Title = ({ subtitle, title }: TitlePropTypes) => {
+const Title = ({ subtitle, title, variant = 'default' }: TitlePropTypes) => {
   return (
-    <div>
-      <h3 className={subtitleStyle}>{subtitle}</h3>
-      <h1 className={titleStyle}>{title}</h1>
+    <div className={styles.container({ variant })}>
+      <h3 className={styles.subtitleStyle({ variant })}>{subtitle}</h3>
+      <h1 className={styles.titleStyle({ variant })}>{title}</h1>
     </div>
   );
 };

--- a/src/common/components/title/title.css.ts
+++ b/src/common/components/title/title.css.ts
@@ -1,31 +1,114 @@
-import { style } from '@vanilla-extract/css';
 import { media } from '@/shared/styles/media';
 import { typography, color } from '@/shared/styles';
+import { recipe } from '@vanilla-extract/recipes';
 
-export const subtitleStyle = style({
-  ...typography.correction,
-  ...typography.desktop.h3,
-  color: color.text.tertiary,
-  '@media': {
-    [media.tablet]: {
-      ...typography.tablet.h3,
+/**
+ * Title 컴포넌트 컨테이너 스타일
+ * articleHeader만 gap 존재
+ */
+export const container = recipe({
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  variants: {
+    variant: {
+      default: {
+        gap: 0,
+      },
+      articleHeader: {
+        gap: '0.625rem',
+      },
+      articleSummary: {},
     },
-    [media.mobile]: {
-      ...typography.phone.h3,
-    },
+  },
+  defaultVariants: {
+    variant: 'default',
   },
 });
 
-export const titleStyle = style({
-  ...typography.correction,
-  ...typography.desktop.h1,
-  color: color.text.main,
-  '@media': {
-    [media.tablet]: {
-      ...typography.tablet.h1,
+/**
+ * 부제목 스타일
+ * articleSummary만 타이포 상이
+ */
+export const subtitleStyle = recipe({
+  base: {
+    ...typography.correction,
+    ...typography.desktop.h3,
+    color: color.text.tertiary,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    '@media': {
+      [media.tablet]: {
+        ...typography.tablet.h3,
+      },
+      [media.mobile]: {
+        ...typography.phone.h3,
+      },
     },
-    [media.mobile]: {
-      ...typography.phone.h1,
+  },
+  variants: {
+    variant: {
+      default: {},
+      articleHeader: {},
+      articleSummary: {
+        ...typography.desktop.h4,
+        '@media': {
+          [media.tablet]: {
+            ...typography.tablet.body1,
+          },
+          [media.mobile]: {
+            ...typography.phone.body2,
+          },
+        },
+      },
     },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+/**
+ * 메인 제목 스타일
+ * articleHeader만 타이포 상이
+ */
+export const titleStyle = recipe({
+  base: {
+    ...typography.correction,
+    ...typography.desktop.h1,
+    color: color.text.main,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    '@media': {
+      [media.tablet]: {
+        ...typography.tablet.h1,
+      },
+      [media.mobile]: {
+        ...typography.phone.h1,
+      },
+    },
+  },
+  variants: {
+    variant: {
+      default: {},
+      articleHeader: {
+        ...typography.desktop.display,
+        '@media': {
+          [media.tablet]: {
+            ...typography.tablet.display,
+          },
+          [media.mobile]: {
+            ...typography.phone.display,
+          },
+        },
+      },
+      articleSummary: {},
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
   },
 });

--- a/src/common/components/title/title.css.ts
+++ b/src/common/components/title/title.css.ts
@@ -36,9 +36,6 @@ export const subtitleStyle = recipe({
     ...typography.correction,
     ...typography.desktop.h3,
     color: color.text.tertiary,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
     '@media': {
       [media.tablet]: {
         ...typography.tablet.h3,
@@ -73,15 +70,18 @@ export const subtitleStyle = recipe({
 /**
  * 메인 제목 스타일
  * articleHeader만 타이포 상이
+ * 2줄 초과 시 말줄임표 부여
  */
 export const titleStyle = recipe({
   base: {
     ...typography.correction,
     ...typography.desktop.h1,
     color: color.text.main,
+    display: '-webkit-box',
+    WebkitBoxOrient: 'vertical',
+    WebkitLineClamp: 2,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
     '@media': {
       [media.tablet]: {
         ...typography.tablet.h1,


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #70 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- Title 컴포넌트에 variant prop 추가하여 recipe로 스타일 분기
  - `'default'` : 기존 이념 페이지 섹션별 타이틀
  - `'articleHeader'` : 기사 상세 페이지 헤더 타이틀 (SCOPE/주제 키워드) - gap 존재
  - `'articleSummary' `: 기사 상세 페이지 기사 요약 섹션 타이틀 (언론사명/기사제목)

| 속성 | `default` | `articleHeader` | `articleSummary` |
|------|-----------|-----------------|------------------|
| Container Gap | `0` | `0.625rem (10px)` | `0` |
| Subtitle (부제목) | h3 | h3 | h4/body1/body2 |
| Title (제목) | h1 | display | h1 |

#### 디바이스별 타이포그래피

- Subtitle (부제목)

| Variant | Desktop | Tablet | Mobile |
|---------|---------|--------|--------|
| `default` | h3 | h3 | h3 |
| `articleHeader` | h3 | h3 | h3 |
| `articleSummary` | h4 | body1 | body2 |

- Title (제목)

| Variant | Desktop | Tablet | Mobile |
|---------|---------|--------|--------|
| `default` | h1 | h1 | h1 |
| `articleHeader` | display | display | display |
| `articleSummary` | h1 | h1 | h1 |


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
#### Title 컴포넌트 사용 방법
```ts
'use client';

import Title from '@/common/components/title/Title';

export default function Home() {
  return (
      {/* variant: 'default' - 기본 스타일 */}
        <Title subtitle="HOT ISSUE" title="핫 이슈 모아보기" />

      {/* variant: 'articleHeader' - 기사 헤더 */}
        <Title subtitle="SCOPE" title="주제 키워드" variant="articleHeader" />

      {/* variant: 'articleSummary' - 기사 요약 */}
        <Title
          subtitle="언론사명"
          title="기사 본연의 제목을 표시해주세요."
          variant="articleSummary"
        />
    </div>
  );
}

```

#### Props
```ts
/**
 * 타이틀 섹션 Props
 * @property {'default' | 'articleHeader' | 'articleSummary'} variant - 레이아웃 스타일 변형
 * - default : 기본 이념 페이지 섹션별 타이틀
 * - articleHeader : SCOPE 기사 상세 페이지 헤더 타이틀 (SCOPE/주제키워드)
 * - articleSummary : SCOPE 기사 상세 페이지 기사 요약 섹션 타이틀 (언론사명/기사제목)
 */
interface TitlePropTypes {
  subtitle: string;
  title: string;
  variant?: 'default' | 'articleHeader' | 'articleSummary';
}
```

### 말줄임표 구현
- 기사 요약 섹션에서 기사 본연의 제목이 2줄 이상일 수 있으므로, 현재 1줄 초과시 말줄임표를 부여하도록 구현되어 있습니다.
- 우현님께 컨펌받고 다시 반영하도록 하겠습니다.


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| Desktop | Tablet | Mobile |
|--|--|--|
| <img width="407" height="443" alt="스크린샷 2026-04-30 오전 2 22 31" src="https://github.com/user-attachments/assets/90fda949-b0c2-4844-8179-7959c7d56c63" /> | <img width="367" height="415" alt="스크린샷 2026-04-30 오전 2 23 01" src="https://github.com/user-attachments/assets/a88db16b-acd2-4faa-a889-608d7ace279d" /> | <img width="208" height="283" alt="스크린샷 2026-04-30 오전 2 23 24" src="https://github.com/user-attachments/assets/25138242-480f-4efd-8eaa-5fe1b1450e5a" /> |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Title 컴포넌트에 선택 가능한 시각적 변형(기본, 기사 헤더, 기사 요약) 추가

* **스타일**
  * 제목에 2줄 절단(ellipsis) 적용으로 긴 텍스트 깔끔하게 표시
  * 요약/헤더에 따른 반응형 타이포그래피 개선
  * 타이틀 블록의 레이아웃 간격 조정으로 시각적 계층 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->