### PR TITLE
[Feat] ArticleDetailActions 컴포넌트 구현

### DIFF
--- a/public/icons/ic_bookmark_filled.svg
+++ b/public/icons/ic_bookmark_filled.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19 21L12 16L5 21V5C5 4.46957 5.21071 3.96086 5.58579 3.58579C5.96086 3.21071 6.46957 3 7 3H17C17.5304 3 18.0391 3.21071 18.4142 3.58579C18.7893 3.96086 19 4.46957 19 5V21Z" fill="#767676" stroke="#767676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/ic_bookmark_outlined.svg
+++ b/public/icons/ic_bookmark_outlined.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19 21L12 16L5 21V5C5 4.46957 5.21071 3.96086 5.58579 3.58579C5.96086 3.21071 6.46957 3 7 3H17C17.5304 3 18.0391 3.21071 18.4142 3.58579C18.7893 3.96086 19 4.46957 19 5V21Z" stroke="#767676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/ic_share.svg
+++ b/public/icons/ic_share.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 12V20C4 20.5304 4.21071 21.0391 4.58579 21.4142C4.96086 21.7893 5.46957 22 6 22H18C18.5304 22 19.0391 21.7893 19.4142 21.4142C19.7893 21.0391 20 20.5304 20 20V12M16 6L12 2M12 2L8 6M12 2V15" stroke="#767676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/app/(main)/article/components/articleDetailActions/ArticleDetailActions.tsx
+++ b/src/app/(main)/article/components/articleDetailActions/ArticleDetailActions.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import Image from 'next/image';
+import { useEffect, useRef, useState } from 'react';
+
+import { useMediaQuery } from '@/shared/hooks/useMediaQuery';
+
+import { BUTTON_TEXT, ICON_PATH, TOAST_DURATION_MS, TOAST_MESSAGE } from './constants';
+import * as styles from './articleDetailActions.css';
+
+interface ArticleDetailActionsPropTypes {
+  isScraped: boolean;
+  onShareClick: () => void;
+  onScrapClick: () => void;
+}
+
+const ArticleDetailActions = ({
+  isScraped,
+  onShareClick,
+  onScrapClick,
+}: ArticleDetailActionsPropTypes) => {
+  // 버튼 텍스트 구분을 위해 모바일 환경인지 확인
+  const breakpoint = useMediaQuery();
+
+  // 토스트 메시지 상태: 스크랩 성공 또는 취소 메시지 표시
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+
+  // 토스트 메시지 타이머 리프: 토스트 메시지 지속 시간 관리 (2초)
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // 공유 아이콘 경로
+  const shareIconPath = ICON_PATH.share;
+
+  // 스크랩 아이콘 경로
+  const bookmarkIconPath = isScraped ? ICON_PATH.bookmarkFilled : ICON_PATH.bookmarkOutlined;
+
+  // 공유 버튼 텍스트
+  const shareButtonText =
+    breakpoint === 'mobile' ? BUTTON_TEXT.share.mobile : BUTTON_TEXT.share.default;
+
+  // 스크랩 버튼 텍스트
+  const scrapButtonText =
+    breakpoint === 'mobile'
+      ? BUTTON_TEXT.scrap.mobile
+      : isScraped
+        ? BUTTON_TEXT.scrap.cancel
+        : BUTTON_TEXT.scrap.create;
+
+  /**
+   * 스크랩 버튼 클릭 핸들러
+   * 스크랩 성공 또는 취소 메시지 표시 및 토스트 메시지 지속 시간 관리
+   */
+  const handleScrapClick = () => {
+    onScrapClick();
+    setToastMessage(isScraped ? TOAST_MESSAGE.scrapCancelSuccess : TOAST_MESSAGE.scrapSuccess);
+
+    if (toastTimerRef.current) {
+      clearTimeout(toastTimerRef.current);
+    }
+
+    toastTimerRef.current = setTimeout(() => {
+      setToastMessage(null);
+    }, TOAST_DURATION_MS);
+  };
+
+  /**
+   * 토스트 메시지 타이머 리프: 토스트 메시지 지속 시간 관리 (2초)
+   * 토스트 메시지 지속 시간 만료 시 토스트 메시지 제거
+   */
+  useEffect(() => {
+    return () => {
+      if (toastTimerRef.current) {
+        clearTimeout(toastTimerRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <div className={styles.container}>
+      <button className={styles.actionButton} onClick={onShareClick}>
+        <Image
+          className={styles.actionIcon}
+          src={shareIconPath}
+          width={24}
+          height={24}
+          alt="share"
+        />
+        <span className={styles.actionText}>{shareButtonText}</span>
+      </button>
+      <div className={styles.scrapButtonContainer}>
+        <button className={styles.actionButton} onClick={handleScrapClick}>
+          <Image
+            className={styles.actionIcon}
+            src={bookmarkIconPath}
+            width={24}
+            height={24}
+            alt="bookmark"
+          />
+          <span className={styles.actionText}>{scrapButtonText}</span>
+        </button>
+        {toastMessage && (
+          <div className={styles.scrapToast} role="status" aria-live="polite">
+            {toastMessage}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ArticleDetailActions;

--- a/src/app/(main)/article/components/articleDetailActions/ArticleDetailActions.tsx
+++ b/src/app/(main)/article/components/articleDetailActions/ArticleDetailActions.tsx
@@ -14,6 +14,11 @@ interface ArticleDetailActionsPropTypes {
   onScrapClick: () => void;
 }
 
+interface ToastStateTypes {
+  id: number;
+  message: string;
+}
+
 const ArticleDetailActions = ({
   isScraped,
   onShareClick,
@@ -23,7 +28,7 @@ const ArticleDetailActions = ({
   const breakpoint = useMediaQuery();
 
   // 토스트 메시지 상태: 스크랩 성공 또는 취소 메시지 표시
-  const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const [toast, setToast] = useState<ToastStateTypes | null>(null);
 
   // 토스트 메시지 타이머 리프: 토스트 메시지 지속 시간 관리 (2초)
   const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -49,17 +54,24 @@ const ArticleDetailActions = ({
   /**
    * 스크랩 버튼 클릭 핸들러
    * 스크랩 성공 또는 취소 메시지 표시 및 토스트 메시지 지속 시간 관리
+   * 토스트 메시지 아이디 증가 및 메시지 설정 - 토스트 메시지 유니크 키 생성
    */
   const handleScrapClick = () => {
     onScrapClick();
-    setToastMessage(isScraped ? TOAST_MESSAGE.scrapCancelSuccess : TOAST_MESSAGE.scrapSuccess);
+    const nextToastMessage = isScraped
+      ? TOAST_MESSAGE.scrapCancelSuccess
+      : TOAST_MESSAGE.scrapSuccess;
+    setToast((prevToast) => ({
+      id: (prevToast?.id ?? 0) + 1,
+      message: nextToastMessage,
+    }));
 
     if (toastTimerRef.current) {
       clearTimeout(toastTimerRef.current);
     }
 
     toastTimerRef.current = setTimeout(() => {
-      setToastMessage(null);
+      setToast(null);
     }, TOAST_DURATION_MS);
   };
 
@@ -98,9 +110,9 @@ const ArticleDetailActions = ({
           />
           <span className={styles.actionText}>{scrapButtonText}</span>
         </button>
-        {toastMessage && (
-          <div className={styles.scrapToast} role="status" aria-live="polite">
-            {toastMessage}
+        {toast && (
+          <div key={toast.id} className={styles.scrapToast} role="status" aria-live="polite">
+            {toast.message}
           </div>
         )}
       </div>

--- a/src/app/(main)/article/components/articleDetailActions/articleDetailActions.css.ts
+++ b/src/app/(main)/article/components/articleDetailActions/articleDetailActions.css.ts
@@ -1,5 +1,24 @@
-import { style } from '@vanilla-extract/css';
+import { keyframes, style } from '@vanilla-extract/css';
 import { color, typography, media, zIndex } from '@/shared/styles';
+
+const toastFadeInOut = keyframes({
+  '0%': {
+    opacity: 0,
+    marginTop: '0.375rem',
+  },
+  '15%': {
+    opacity: 1,
+    marginTop: '0',
+  },
+  '85%': {
+    opacity: 1,
+    marginTop: '0',
+  },
+  '100%': {
+    opacity: 0,
+    marginTop: '-0.25rem',
+  },
+});
 
 export const container = style({
   width: '100%',
@@ -56,6 +75,7 @@ export const scrapToast = style({
   padding: '1.25rem 1.875rem',
   whiteSpace: 'nowrap',
   zIndex: zIndex.toast,
+  animation: `${toastFadeInOut} 2s ease-in-out forwards`,
   '@media': {
     [media.tablet]: {
       ...typography.tablet.body2,

--- a/src/app/(main)/article/components/articleDetailActions/articleDetailActions.css.ts
+++ b/src/app/(main)/article/components/articleDetailActions/articleDetailActions.css.ts
@@ -1,0 +1,88 @@
+import { style } from '@vanilla-extract/css';
+import { color, typography, media, zIndex } from '@/shared/styles';
+
+export const container = style({
+  width: '100%',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '2.19rem',
+  '@media': {
+    [media.tablet]: {
+      gap: '1.56rem',
+    },
+    [media.mobile]: {
+      gap: '0.94rem',
+    },
+  },
+});
+
+export const actionButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+  cursor: 'pointer',
+  '@media': {
+    [media.mobile]: {
+      gap: '0.19rem',
+    },
+  },
+});
+
+export const scrapButtonContainer = style({
+  position: 'relative',
+});
+
+export const actionIcon = style({
+  width: '1.5rem',
+  height: '1.5rem',
+  '@media': {
+    [media.mobile]: {
+      width: '1.125rem',
+      height: '1.125rem',
+    },
+  },
+});
+
+export const scrapToast = style({
+  ...typography.correction,
+  ...typography.desktop.body2,
+  backgroundColor: color.brand.main,
+  color: color.text.inverse,
+  position: 'absolute',
+  top: 'calc(100% + 0.62rem)',
+  left: '50%',
+  transform: 'translateX(-50%)',
+  borderRadius: '0.3125rem',
+  padding: '1.25rem 1.875rem',
+  whiteSpace: 'nowrap',
+  zIndex: zIndex.toast,
+  '@media': {
+    [media.tablet]: {
+      ...typography.tablet.body2,
+      top: 'calc(100% + 0.62rem)',
+      left: '100%',
+      transform: 'translateX(-100%)',
+    },
+    [media.mobile]: {
+      ...typography.phone.body2,
+      position: 'fixed',
+      top: '50%',
+      left: '50%',
+      transform: 'translate(-50%, -50%)',
+    },
+  },
+});
+
+export const actionText = style({
+  ...typography.correction,
+  ...typography.desktop.h4,
+  color: color.text.tertiary,
+  '@media': {
+    [media.tablet]: {
+      ...typography.tablet.h4,
+    },
+    [media.mobile]: {
+      ...typography.phone.body2,
+    },
+  },
+});

--- a/src/app/(main)/article/components/articleDetailActions/constants.ts
+++ b/src/app/(main)/article/components/articleDetailActions/constants.ts
@@ -1,0 +1,24 @@
+export const ICON_PATH = {
+  share: '/icons/ic_share.svg',
+  bookmarkFilled: '/icons/ic_bookmark_filled.svg',
+  bookmarkOutlined: '/icons/ic_bookmark_outlined.svg',
+} as const;
+
+export const BUTTON_TEXT = {
+  share: {
+    mobile: '공유',
+    default: '공유하기',
+  },
+  scrap: {
+    mobile: '스크랩',
+    create: '스크랩하기',
+    cancel: '스크랩취소',
+  },
+} as const;
+
+export const TOAST_MESSAGE = {
+  scrapSuccess: '콘텐츠가 스크랩되었습니다.',
+  scrapCancelSuccess: '콘텐츠 스크랩이 취소되었습니다.',
+} as const;
+
+export const TOAST_DURATION_MS = 2000;

--- a/src/shared/styles/global.css.ts
+++ b/src/shared/styles/global.css.ts
@@ -61,6 +61,9 @@ globalStyle('img, video', {
 /* Set default button styles */
 globalStyle('button', {
   cursor: 'pointer',
+  border: 'none',
+  backgroundColor: 'transparent',
+  padding: 0,
 });
 
 /* Remove default input and textarea styles */

--- a/src/shared/styles/zIndex.css.ts
+++ b/src/shared/styles/zIndex.css.ts
@@ -7,6 +7,7 @@ export const zIndex = {
   carouselCard: 10, // ScopeCarouselItem 내부 cardContent
   carouselBar: 20, // ScopeCarouselItem 내부 ideologyBar
   header: 100,
+  toast: 200,
   overlay: 1000,
   dialogContent: 1001,
 } as const;


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #82 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- ArticleDetailActions 컴포넌트 구현
- 공유/스크랩 아이콘 에셋 추가 및 액션 버튼 UI 반영
- 스크랩 상태(isScraped)에 따라 아이콘/문구 동적 변경 처리
- 스크랩 클릭 시 성공/취소 토스트 메시지 노출(2초) 로직 추가
- 토스트 노출 위치 반응형 적용(데스크탑/태블릿: 버튼 하단, 모바일: 화면 중앙)
- 토스트 페이드 인/아웃 + 슬라이드 모션 애니메이션 적용
- 액션 버튼/토스트 관련 하드코딩 문자열 및 경로를 constants.ts로 분리
- 전역 버튼 기본 스타일(border/background/padding) 초기화 추가
- z-index 토큰에 toast 계층 추가


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
### ArticleDetailActions 컴포넌트 사용 방법

```ts
import ArticleDetailActions from '@/app/(main)/article/components/articleDetailActions/ArticleDetailActions';
import { useState } from 'react';

  const [isScraped, setIsScraped] = useState(false);
  const handleShareClick = () => {
    console.log('share');
  };
  const handleScrapClick = () => {
    setIsScraped(!isScraped);
  };
  return (
    <div>
      <ArticleDetailActions
        isScraped={isScraped}
        onShareClick={handleShareClick}
        onScrapClick={handleScrapClick}
      />
    </div>
    );
};
```
**prop**
- `isScraped`
  - 현재 스크랩 상태를 나타내는 boolean 값
- `onShareClick`
  - 공유 버튼 클릭 시 실행되는 콜백 함수
  - 현재 placeholder 핸들러로 연결되어 있으며, 이후 `ShareModal` 오픈 로직으로 교체 예정입니다.
- `onScrapClick`
  - 스크랩 버튼 클릭 시 실행되는 콜백 함수
  - 스크랩 상태 변경(API 호출, 상태 업데이트)은 부모 컴포넌트에서 처리
  - 스크랩 클릭 시 토스트는 컴포넌트 내부에서 처리되며 2초간 노출됩니다.

### ZIndex 토스트 토큰 추가
```ts
export const zIndex = {
  base: 0,
  carouselCard: 10, // ScopeCarouselItem 내부 cardContent
  carouselBar: 20, // ScopeCarouselItem 내부 ideologyBar
  header: 100,
  toast: 200,  // 추가
  overlay: 1000,
  dialogContent: 1001,
} as const;
```

## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| Desktop | Tablet | Mobile |
|--|--|--|
| <img width="370" height="191" alt="스크린샷_데스크탑" src="https://github.com/user-attachments/assets/f0943d20-7542-430b-a884-4ae60e6101f6" /> | <img width="227" height="125" alt="스크린샷_태블릿" src="https://github.com/user-attachments/assets/0cb87e44-e47a-4798-81be-227a3de65c5b" /> | <img width="330" height="714" alt="image" src="https://github.com/user-attachments/assets/04e763df-4f0a-496d-b5fc-28f8c4e2ae1e" /> |



