### PR TITLE
[Feat] LinkDetailBody 컴포넌트 구현

### DIFF
--- a/src/app/(main)/article/link/[id]/components/linkDetailBody/LinkDetailBody.tsx
+++ b/src/app/(main)/article/link/[id]/components/linkDetailBody/LinkDetailBody.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import * as styles from './linkDetailBody.css';
+import DefaultButton from '@/common/components/defaultButton/DefaultButton';
+
+interface LinkDetailBodyPropTypes {
+  summary: string;
+  articleUrl: string;
+}
+
+const LinkDetailBody = ({ summary, articleUrl }: LinkDetailBodyPropTypes) => {
+  const handleOriginalArticleClick = () => {
+    window.open(articleUrl, '_blank');
+  };
+  return (
+    <div className={styles.container}>
+      <div className={styles.summaryText}>{summary}</div>
+      <div className={styles.buttonContainer}>
+        <DefaultButton label="기사 원문 보기" onClick={handleOriginalArticleClick} />
+      </div>
+    </div>
+  );
+};
+
+export default LinkDetailBody;

--- a/src/app/(main)/article/link/[id]/components/linkDetailBody/LinkDetailBody.tsx
+++ b/src/app/(main)/article/link/[id]/components/linkDetailBody/LinkDetailBody.tsx
@@ -10,7 +10,7 @@ interface LinkDetailBodyPropTypes {
 
 const LinkDetailBody = ({ summary, articleUrl }: LinkDetailBodyPropTypes) => {
   const handleOriginalArticleClick = () => {
-    window.open(articleUrl, '_blank');
+    window.open(articleUrl, '_blank', 'noopener,noreferrer');
   };
   return (
     <div className={styles.container}>

--- a/src/app/(main)/article/link/[id]/components/linkDetailBody/linkDetailBody.css.ts
+++ b/src/app/(main)/article/link/[id]/components/linkDetailBody/linkDetailBody.css.ts
@@ -1,0 +1,40 @@
+import { style } from '@vanilla-extract/css';
+import { color, typography, media } from '@/shared/styles';
+
+export const container = style({
+  width: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '3.12rem',
+});
+
+export const summaryText = style({
+  ...typography.correction,
+  ...typography.desktop.body1,
+  color: color.text.main,
+  alignSelf: 'stretch',
+  wordBreak: 'keep-all',
+  overflowWrap: 'break-word',
+  whiteSpace: 'pre-wrap',
+  '@media': {
+    [media.tablet]: {
+      ...typography.tablet.body1,
+    },
+    [media.mobile]: {
+      ...typography.phone.body1,
+    },
+  },
+});
+
+export const buttonContainer = style({
+  width: '100%',
+  minWidth: '7.5625rem',
+  '@media': {
+    [media.tablet]: {
+      minWidth: '7.875rem',
+    },
+    [media.mobile]: {
+      minWidth: '6.125rem',
+    },
+  },
+});


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #85 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
### LinkDetailBody 컴포넌트 사용 방법
```ts
import LinkDetailBody from '@/app/(main)/article/link/[id]/components/linkDetailBody/LinkDetailBody';

export default function LinkArticlePage() {
  return (
    <>
      <LinkDetailBody
        summary="다음은 주제 키워드에 대해 각 성향의 기사들이 어떤 식으로 서술하고 있는지 기사 성향을 설명하는 내용입니다. 예를 들어 “진보 성향으로 서술된 기사의 경우, 주제 키워드에 대해 ~식으로 묘사하고 있는 반면 보수 성향 기사는 ~식으로 표현하고 있습니다. 독자는 각기 다른 주제 키워드에 대한 책임 소재에 유의하길 바랍니다.”와 같이 주제 키워드에 대해 각 기사들이 어떻게 표현하고 있는지 묘사합니다."
        articleUrl="https://www.naver.com"
      />
    </>
  );
}
```

**prop**
- `summary`
  - 기사 요약 내용 텍스트
- `articleUrl`
  - 기사 원문 링크

## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| Desktop | Tablet | Mobile |
|--|--|--|
| <img width="910" height="167" alt="스크린샷 2026-05-02 오후 6 35 53" src="https://github.com/user-attachments/assets/e89a8a7d-f25a-4beb-8148-d21e689ebe0c" /> | <img width="771" height="192" alt="스크린샷 2026-05-02 오후 6 36 21" src="https://github.com/user-attachments/assets/c36dc9c3-37d3-479e-871e-b9f749e3d4a9" /> | <img width="322" height="223" alt="스크린샷 2026-05-02 오후 6 36 50" src="https://github.com/user-attachments/assets/b3ef24db-0408-407b-8801-04b50524463d" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 기사 링크 상세 페이지에 기사 요약 표시 및 "기사 원문 보기" 버튼 추가
  * 원문 보기 버튼 클릭 시 해당 기사 URL이 새 탭에서 열림
  * 반응형 스타일 적용으로 데스크톱, 태블릿, 모바일에서 읽기 최적화된 레이아웃 제공
<!-- end of auto-generated comment: release notes by coderabbit.ai -->