### PR TITLE
[Feat] LinkDetailHeader 컴포넌트 구현

### DIFF
--- a/src/app/(main)/article/link/[id]/components/linkDetailHeader/LinkDetailHeader.tsx
+++ b/src/app/(main)/article/link/[id]/components/linkDetailHeader/LinkDetailHeader.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import * as styles from './linkDetailHeader.css';
+import { useState } from 'react';
+
 import ArticleDetailActions from '@/app/(main)/article/components/articleDetailActions/ArticleDetailActions';
 import IdeologyIndicator from '@/common/components/indicator/IdeologyIndicator';
-import { useState } from 'react';
 import { IdeologyIndicatorValueTypes } from '@/common/components/indicator/constants';
+
+import * as styles from './linkDetailHeader.css';
 
 interface LinkDetailHeaderPropTypes {
   id: number;

--- a/src/app/(main)/article/link/[id]/components/linkDetailHeader/LinkDetailHeader.tsx
+++ b/src/app/(main)/article/link/[id]/components/linkDetailHeader/LinkDetailHeader.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import * as styles from './linkDetailHeader.css';
+import ArticleDetailActions from '@/app/(main)/article/components/articleDetailActions/ArticleDetailActions';
+import IdeologyIndicator from '@/common/components/indicator/IdeologyIndicator';
+import { useState } from 'react';
+import { IdeologyIndicatorValueTypes } from '@/common/components/indicator/constants';
+
+interface LinkDetailHeaderPropTypes {
+  id: number;
+  title: string;
+  newsAgencyName: string;
+  publishedAt: string;
+  frameType: IdeologyIndicatorValueTypes;
+  isScraped: boolean;
+}
+
+const LinkDetailHeader = ({
+  id,
+  title,
+  newsAgencyName,
+  publishedAt,
+  frameType,
+  isScraped,
+}: LinkDetailHeaderPropTypes) => {
+  const [localIsScraped, setIsScraped] = useState(isScraped);
+  const handleShareClick = () => {
+    console.log('share');
+  };
+  const handleScrapClick = () => {
+    setIsScraped((prev: boolean) => !prev);
+    console.log(id);
+  };
+  return (
+    <div className={styles.container}>
+      <div className={styles.titleContainer}>
+        <div className={styles.newsAgencyNameText}>{newsAgencyName}</div>
+        <div className={styles.titleText}>{title}</div>
+        <div className={styles.ideologyIndicatorContainer}>
+          <IdeologyIndicator
+            value={frameType}
+            size={{ desktop: 'large', tablet: 'large', mobile: 'large' }}
+          />
+        </div>
+      </div>
+      <div className={styles.infoContainer}>
+        <div className={styles.publishedAtText}>{publishedAt}</div>
+        <div>
+          <ArticleDetailActions
+            isScraped={localIsScraped}
+            onShareClick={handleShareClick}
+            onScrapClick={handleScrapClick}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LinkDetailHeader;

--- a/src/app/(main)/article/link/[id]/components/linkDetailHeader/linkDetailHeader.css.ts
+++ b/src/app/(main)/article/link/[id]/components/linkDetailHeader/linkDetailHeader.css.ts
@@ -1,0 +1,113 @@
+import { style } from '@vanilla-extract/css';
+import { color, typography, media } from '@/shared/styles';
+
+export const container = style({
+  width: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.88rem',
+  borderBottom: `1px solid ${color.brand.gray1}`,
+  paddingBottom: '1.88rem',
+  '@media': {
+    [media.mobile]: {
+      gap: '3.12rem',
+      paddingBottom: '0.62rem',
+    },
+  },
+});
+
+export const titleContainer = style({
+  display: 'grid',
+  gap: '0.62rem',
+  gridTemplateColumns: 'minmax(0, 1fr) max-content',
+  gridTemplateAreas: `
+    "title title"
+    "news indicator"
+  `,
+  alignItems: 'center',
+  '@media': {
+    [media.mobile]: {
+      gridTemplateColumns: '1fr',
+      gridTemplateAreas: `
+        "news"
+        "title"
+        "indicator"
+      `,
+    },
+  },
+});
+
+export const newsAgencyNameText = style({
+  gridArea: 'news',
+  minWidth: 0,
+  ...typography.correction,
+  ...typography.desktop.h3,
+  color: color.text.tertiary,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  '@media': {
+    [media.tablet]: {
+      ...typography.tablet.h3,
+    },
+    [media.mobile]: {
+      ...typography.phone.h3,
+      overflow: 'visible',
+      textOverflow: 'clip',
+      whiteSpace: 'normal',
+    },
+  },
+});
+
+export const titleText = style({
+  gridArea: 'title',
+  minWidth: 0,
+  ...typography.correction,
+  ...typography.desktop.display,
+  color: color.text.main,
+  '@media': {
+    [media.tablet]: {
+      ...typography.tablet.display,
+    },
+    [media.mobile]: {
+      ...typography.phone.h1,
+    },
+  },
+});
+
+export const ideologyIndicatorContainer = style({
+  gridArea: 'indicator',
+  width: 'max-content',
+  minWidth: '15.8125rem',
+  maxWidth: 'none',
+  justifySelf: 'end',
+  '@media': {
+    [media.mobile]: {
+      width: '100%',
+      minWidth: 0,
+      maxWidth: '15.8125rem',
+      justifySelf: 'stretch',
+    },
+  },
+});
+
+export const infoContainer = style({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+});
+
+export const publishedAtText = style({
+  ...typography.correction,
+  ...typography.desktop.h4,
+  color: color.text.tertiary,
+  '@media': {
+    [media.tablet]: {
+      ...typography.tablet.h4,
+    },
+    [media.mobile]: {
+      ...typography.phone.body2,
+    },
+  },
+});


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #89 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- LinkDetailHeader 컴포넌트 구현

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
### LinkDetailHeader 컴포넌트 사용 방법
```ts
import LinkDetailHeader from './components/linkDetailHeader/LinkDetailHeader';

export default function LinkArticlePage() {
  return (
    <>
      <LinkDetailHeader
        id={1}
        title="기사 제목이 길다면 어떻게 될지 한번 봅시다. 말줄임표없이 긴대로 모두 노출시켜주세요."
        newsAgencyName="언론사명"
        publishedAt="2026-04-27"
        frameType="STRONG_NORM"
        isScraped={false}
      />
    </>
  );
}
```

**prop**
- `id`
  - 기사 고유 식별자
- `title`
  - 기사 제목
- `newsAgencyName`
  - 기사 출처 언론사명
- `publishedAt`
  - 기사 발행일
- `frameType`
  - 기사 프레임 유형
- `isScraped`
  - 사용자의 스크랩 여부

## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| Desktop | Tablet | Mobile |
|--|--|--|
| <img width="1134" height="255" alt="스크린샷 2026-05-03 오후 12 56 05" src="https://github.com/user-attachments/assets/b2835804-33f7-4e08-a5dc-55dc30aa33dc" /> | <img width="446" height="143" alt="스크린샷 2026-05-03 오후 12 56 28" src="https://github.com/user-attachments/assets/0d4e45f9-673e-455e-b520-3aa536356780" /> | <img width="318" height="188" alt="스크린샷 2026-05-03 오후 12 56 50" src="https://github.com/user-attachments/assets/eaab91b8-2536-4f72-a34b-b53ae0d85356" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 기사 링크 상세 페이지에 헤더 영역 추가: 뉘스사 이름, 제목, 정치 성향 지표, 발행일 정보 표시
  * 스크랩 및 공유 기능이 포함된 액션 버튼 추가
  * 모바일과 태블릿을 포함한 다양한 화면 크기에 최적화된 반응형 디자인 적용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->