### PR TITLE
[Refactor] ReportSummarySection 컴포넌트 prop 구조 변경

### DIFF
--- a/src/app/(main)/article/components/reportSummarySection/ReportSummarySection.tsx
+++ b/src/app/(main)/article/components/reportSummarySection/ReportSummarySection.tsx
@@ -7,37 +7,50 @@ import * as styles from './reportSummarySection.css';
 import { IDEOLOGY_LABELS, ITEM_LABELS } from './constants';
 
 /**
- * @property totalNewsCount       - 총 뉴스 수 (선택적, desktop 전용)
- * @property progressiveCount     - 진보성향 기사 수
- * @property conservativeCount    - 보수성향 기사 수
- * @property centerCount          - 중도성향 기사 수
- * @property biasIdeology         - 편향 이념
- * @property biasPercentage       - 편향 퍼센트 (0–100)
- * @property relatedArticleCount  - 연관 기사 수 (선택적, tablet/mobile 전용)
+ * @property articleCount - 이념별 기사 수 데이터
+ * @property bias - 편향 퍼센트 (0–100)
+ * @property dominantFrameType - 편향 이념 (VALUE, NORM, NEUTRAL)
+ * @property relatedArticleCount - 연관 기사 수 (선택적, tablet/mobile 전용)
  */
 interface ReportSummarySectionPropTypes {
-  totalNewsCount?: number;
-  progressiveCount: number;
-  conservativeCount: number;
-  centerCount: number;
-  biasIdeology: IdeologyType;
-  biasPercentage: number;
+  articleCount: {
+    neutral: number;
+    neutralRatio: number;
+    norm: number;
+    normRatio: number;
+    value: number;
+    valueRatio: number;
+  };
+  bias: number;
+  dominantFrameType: string;
   relatedArticleCount?: number;
 }
 
 const ReportSummarySection = ({
-  totalNewsCount,
-  progressiveCount,
-  conservativeCount,
-  centerCount,
-  biasIdeology,
-  biasPercentage,
+  articleCount,
+  bias,
+  dominantFrameType,
   relatedArticleCount,
 }: ReportSummarySectionPropTypes) => {
   const breakpoint = useMediaQuery();
   const isMobile = breakpoint === 'mobile';
 
   const label = ITEM_LABELS[breakpoint];
+
+  // 데이터 매핑
+  const valueCount = articleCount.value;
+  const normCount = articleCount.norm;
+  const neutralCount = articleCount.neutral;
+  const totalNewsCount = articleCount.value + articleCount.norm + articleCount.neutral;
+  const biasPercentage = bias;
+
+  // dominantFrameType을 IdeologyType으로 변환 (추후 통일)
+  const biasIdeologyMap: Record<string, IdeologyType> = {
+    VALUE: 'progressive',
+    NORM: 'conservative',
+    NEUTRAL: 'center',
+  };
+  const biasIdeology: IdeologyType = biasIdeologyMap[dominantFrameType] || 'center';
 
   // 숫자 값에 '건' 단위를 붙여 반환 — mobile 전용
   const countValue = (count: number) =>
@@ -62,9 +75,9 @@ const ReportSummarySection = ({
       : []),
 
     // 이념 관점 기사 수
-    { label: label.progressive, value: countValue(progressiveCount) },
-    { label: label.conservative, value: countValue(conservativeCount) },
-    { label: label.center, value: countValue(centerCount) },
+    { label: label.progressive, value: countValue(valueCount) },
+    { label: label.conservative, value: countValue(normCount) },
+    { label: label.center, value: countValue(neutralCount) },
 
     // 편향 분포
     {

--- a/src/app/(main)/article/components/reportSummarySection/ReportSummarySection.tsx
+++ b/src/app/(main)/article/components/reportSummarySection/ReportSummarySection.tsx
@@ -10,7 +10,6 @@ import { IDEOLOGY_LABELS, ITEM_LABELS } from './constants';
  * @property articleCount - 이념별 기사 수 데이터
  * @property bias - 편향 퍼센트 (0–100)
  * @property dominantFrameType - 편향 이념 (VALUE, NORM, NEUTRAL)
- * @property relatedArticleCount - 연관 기사 수 (선택적, tablet/mobile 전용)
  */
 interface ReportSummarySectionPropTypes {
   articleCount: {
@@ -23,14 +22,12 @@ interface ReportSummarySectionPropTypes {
   };
   bias: number;
   dominantFrameType: string;
-  relatedArticleCount?: number;
 }
 
 const ReportSummarySection = ({
   articleCount,
   bias,
   dominantFrameType,
-  relatedArticleCount,
 }: ReportSummarySectionPropTypes) => {
   const breakpoint = useMediaQuery();
   const isMobile = breakpoint === 'mobile';
@@ -63,16 +60,12 @@ const ReportSummarySection = ({
       count
     );
 
-  const items: { label: string; value: React.ReactNode }[] = [
-    // 연관 기사 수 — tablet/mobile 전용
-    ...('relatedArticle' in label && relatedArticleCount !== undefined
-      ? [{ label: label.relatedArticle, value: countValue(relatedArticleCount) }]
-      : []),
+  // 총 뉴스/연관 기사 수 라벨 선택 (모두 같은 totalNewsCount 값 사용)
+  const newsCountLabel = label.totalNews;
 
-    // 총 뉴스 수 — desktop 전용
-    ...('totalNews' in label && totalNewsCount !== undefined
-      ? [{ label: label.totalNews, value: totalNewsCount }]
-      : []),
+  const items: { label: string; value: React.ReactNode }[] = [
+    // 총 뉴스/연관 기사 수 — desktop: 총 뉴스 수, tablet/mobile: 연관 기사 수
+    { label: newsCountLabel, value: countValue(totalNewsCount) },
 
     // 이념 관점 기사 수
     { label: label.progressive, value: countValue(valueCount) },

--- a/src/app/(main)/article/components/reportSummarySection/constants.ts
+++ b/src/app/(main)/article/components/reportSummarySection/constants.ts
@@ -18,14 +18,14 @@ export const ITEM_LABELS = {
     biasDist: '편향 분포',
   },
   tablet: {
-    relatedArticle: '연관 기사 수',
+    totalNews: '연관 기사 수',
     progressive: '진보 관점 기사 수',
     conservative: '보수 관점 기사 수',
     center: '중도 관점 기사 수',
     biasDist: '편향 분포',
   },
   mobile: {
-    relatedArticle: '연관 기사',
+    totalNews: '연관 기사',
     progressive: '진보 관점',
     conservative: '보수 관점',
     center: '중도 관점',


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #97 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- **ReportSummarySection props를 백엔드 응답 형태에 맞게 정리**
  - 기존 평탄한 필드 대신 `articleCount`, `bias`, `dominantFrameType`을 받도록 변경
  - `articleCount`는 이념별 건수·비율(`value` / `norm` / `neutral` 및 각 `*Ratio`)을 포함하는 객체로 통일
  - UI에서 쓰는 진보/보수/중도 건수는 `value` → 진보, `norm` → 보수, `neutral` → 중도로 매핑
  - `dominantFrameType`(`VALUE` | `NORM` | `NEUTRAL`)을 내부 `IdeologyType`으로 변환하는 맵 추가 (추후 리팩토링 예정)
- **총 뉴스 수·연관 기사 수 표기 로직 통일**
  - 데스크톱은 “총 뉴스 수”, 태블릿·모바일은 “연관 기사 수” 라벨을 유지하되, 표시 숫자는 모두 `articleCount` 합(`value` + `norm` + `neutral`)으로 동일하게 사용
  - 선택적 `totalNewsCount` / `relatedArticleCount` 분기 제거로 prop 단순화
- **constants (`ITEM_LABELS`)**
  - 태블릿·모바일에서 `relatedArticle` 키를 `totalNews`로 맞춰, 라벨 소스를 데스크톱과 동일한 키(`totalNews`)로 정리 (표시 문구는 기존과 같이 연관 기사 수 / 연관 기사)

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
#### ReportSummarySection 사용 예시 (변경 후)

```tsx
import ReportSummarySection from '@/app/(main)/article/components/reportSummarySection/ReportSummarySection';
const mockArticleData = {
  articleCount: {
    neutral: 7,
    neutralRatio: 0.39,
    norm: 3,
    normRatio: 0.17,
    value: 8,
    valueRatio: 0.44,
  },
  bias: 44,
  dominantFrameType: 'VALUE',
};
export default function Home() {
  return <ReportSummarySection
          articleCount={mockArticleData.articleCount}
          bias={mockArticleData.bias}
          dominantFrameType={mockArticleData.dominantFrameType} />;
}
```
#### prop
- articleCount — value / norm / neutral 및 각 비율 필드를 포함하는 객체 (백엔드 스키마와 맞춤)
- bias — 편향 퍼센트 (0–100), 기존 biasPercentage 역할
- dominantFrameType — 편향 우세 프레임 타입 문자열

#### 리뷰 포인트
- 기존에 totalNewsCount와 relatedArticleCount를 별도의 데이터로 관리하던 구조를 하나로 통일했습니다.
- 백엔드 응답에서 totalNewsCount를 별도로 제공하지 않아, 컴포넌트 내부에서 각 이념별 기사 수를 합산하여 계산하도록 변경했습니다.
- dominantFrameType이 매핑되지 않은 값일 경우, 기본값으로 'center'를 사용하도록 처리했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 기사 요약 섹션의 데이터 구조를 개선하여 기사 수와 편향도 정보 처리를 최적화했습니다.
  * "연관 기사" 레이블을 "총 뉴스"로 변경하여 정보 표시를 명확히 했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/team-balenz/balenz-client/pull/98)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->