### PR TITLE
[Feat] ScopeDetailBody 컴포넌트 구현

### DIFF
--- a/src/app/(main)/article/scope/[id]/components/articleSummarySection/ArticleSummarySection.tsx
+++ b/src/app/(main)/article/scope/[id]/components/articleSummarySection/ArticleSummarySection.tsx
@@ -7,14 +7,16 @@ import IdeologyIndicator from '@/common/components/indicator/IdeologyIndicator';
 
 import { SUMMARY_CATEGORY_TABS } from '@/app/(main)/(home)/constants';
 import { type ArticleSummarySectionTypes } from '@/app/(main)/article/scope/[id]/types/articleSummarySection';
-import { ARTICLE_SUMMARY_SECTION_DATA } from '@/mocks/data/scopeDetail';
 
 import * as styles from './articleSummarySection.css';
 
-const ArticleSummarySection = () => {
+interface ArticleSummarySectionPropTypes {
+  mainArticles: ArticleSummarySectionTypes;
+}
+
+const ArticleSummarySection = ({ mainArticles }: ArticleSummarySectionPropTypes) => {
   const [summaryActiveKey, setSummaryActiveKey] = useState<string>('progressive');
-  const summaryItem =
-    ARTICLE_SUMMARY_SECTION_DATA[summaryActiveKey as keyof ArticleSummarySectionTypes];
+  const summaryItem = mainArticles[summaryActiveKey as keyof ArticleSummarySectionTypes];
 
   return (
     <div className={styles.container}>

--- a/src/app/(main)/article/scope/[id]/components/scopeDetailBody/ScopeDetailBody.tsx
+++ b/src/app/(main)/article/scope/[id]/components/scopeDetailBody/ScopeDetailBody.tsx
@@ -1,0 +1,43 @@
+import * as style from './scopeDetailBody.css';
+import ReportSummarySection from '@/app/(main)/article/components/reportSummarySection/ReportSummarySection';
+
+interface ScopeDetailBodyArticleCountTypes {
+  neutral: number;
+  neutralRatio: number;
+  norm: number;
+  normRatio: number;
+  value: number;
+  valueRatio: number;
+}
+
+interface ScopeDetailBodyPropTypes {
+  keywordName: string;
+  keywordSummary: string;
+  articleCount: ScopeDetailBodyArticleCountTypes;
+  bias: number;
+  dominantFrameType: string;
+}
+
+const ScopeDetailBody = ({
+  keywordName,
+  keywordSummary,
+  articleCount,
+  bias,
+  dominantFrameType,
+}: ScopeDetailBodyPropTypes) => {
+  return (
+    <div className={style.container}>
+      <div className={style.title}>{keywordName}에 대해 발렌즈가 요약했습니다.</div>
+      <div className={style.articleCount}>
+        <ReportSummarySection
+          articleCount={articleCount}
+          bias={bias}
+          dominantFrameType={dominantFrameType}
+        />
+      </div>
+      <div className={style.content}>{keywordSummary}</div>
+    </div>
+  );
+};
+
+export default ScopeDetailBody;

--- a/src/app/(main)/article/scope/[id]/components/scopeDetailBody/ScopeDetailBody.tsx
+++ b/src/app/(main)/article/scope/[id]/components/scopeDetailBody/ScopeDetailBody.tsx
@@ -10,12 +10,12 @@ interface ScopeDetailBodyArticleCountTypes {
   valueRatio: number;
 }
 
-interface ScopeDetailBodyPropTypes {
+export interface ScopeDetailBodyPropTypes {
   keywordName: string;
   keywordSummary: string;
   articleCount: ScopeDetailBodyArticleCountTypes;
   bias: number;
-  dominantFrameType: string;
+  dominantFrameType: 'VALUE' | 'NEUTRAL' | 'NORM' | 'BALANCED';
 }
 
 const ScopeDetailBody = ({

--- a/src/app/(main)/article/scope/[id]/components/scopeDetailBody/scopeDetailBody.css.ts
+++ b/src/app/(main)/article/scope/[id]/components/scopeDetailBody/scopeDetailBody.css.ts
@@ -1,0 +1,53 @@
+import { style } from '@vanilla-extract/css';
+import { color, typography, media } from '@/shared/styles';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.88rem',
+  '@media': {
+    [media.belowDesktop]: {
+      gap: '1.25rem',
+    },
+  },
+});
+
+export const title = style({
+  ...typography.correction,
+  ...typography.desktop.h1,
+  color: color.text.main,
+  '@media': {
+    [media.tablet]: {
+      ...typography.tablet.h1,
+    },
+    [media.mobile]: {
+      ...typography.phone.h1,
+    },
+  },
+});
+
+export const articleCount = style({
+  display: 'none',
+  '@media': {
+    [media.tablet]: {
+      display: 'block',
+    },
+    [media.mobile]: {
+      display: 'block',
+    },
+  },
+});
+
+export const content = style({
+  ...typography.correction,
+  ...typography.desktop.body1,
+  color: color.text.main,
+  '@media': {
+    [media.tablet]: {
+      ...typography.tablet.body1,
+    },
+    [media.mobile]: {
+      ...typography.phone.body1,
+    },
+  },
+});

--- a/src/app/(main)/article/scope/[id]/types/scopeDetailSection.ts
+++ b/src/app/(main)/article/scope/[id]/types/scopeDetailSection.ts
@@ -1,0 +1,25 @@
+import type { ArticleSummarySectionTypes } from '@/app/(main)/article/scope/[id]/types/articleSummarySection';
+
+export type DominantFrameType = 'VALUE' | 'NEUTRAL' | 'NORM' | 'BALANCED';
+
+export interface ScopeDetailArticleCountTypes {
+  neutral: number;
+  neutralRatio: number;
+  norm: number;
+  normRatio: number;
+  value: number;
+  valueRatio: number;
+}
+
+export interface ScopeDetailTypes {
+  id: number;
+  name: string;
+  imageUrl: string;
+  date: string;
+  viewCount: number;
+  keywordSummary: string;
+  articleCount: ScopeDetailArticleCountTypes;
+  bias: number;
+  dominantFrameType: DominantFrameType;
+  mainArticles: ArticleSummarySectionTypes;
+}

--- a/src/mocks/data/scopeDetail.ts
+++ b/src/mocks/data/scopeDetail.ts
@@ -1,26 +1,47 @@
 import { type ArticleSummarySectionTypes } from '@/app/(main)/article/scope/[id]/types/articleSummarySection';
 
-// scopeDetail 페이지 기사 요약 섹션 데이터
-export const ARTICLE_SUMMARY_SECTION_DATA: ArticleSummarySectionTypes = {
-  center: {
-    frameType: 'NEUTRAL',
-    id: 15,
-    newsAgencyName: '경향신문',
-    summary: '요약요약',
-    title: '기사 제목',
+export const SCOPE_DETAIL_MOCK = {
+  id: 19,
+  name: '고용노동부',
+  imageUrl: 'https://i.pinimg.com/736x/44/b0/f0/44b0f0315ece65cdc3b64130c91ea009.jpg',
+  date: '2026-05-02',
+  viewCount: 14,
+  keywordSummary:
+    '다음은 주제 키워드에 대해 각 성향의 기사들이 어떤 식으로 서술하고 있는지 기사 성향을 설명하는 내용입니다. 예를 들어 “진보 성향으로 서술된 기사의 경우, 주제 키워드에 대해 ~식으로 묘사하고 있는 반면 보수 성향 기사는 ~식으로 표현하고 있습니다. 독자는 각기 다른 주제 키워드에 대한 책임 소재에 유의하길 바랍니다.”와 같이 주제 키워드에 대해 각 기사들이 어떻게 표현하고 있는지 묘사합니다.',
+  articleCount: {
+    neutral: 7,
+    neutralRatio: 0.39,
+    norm: 3,
+    normRatio: 0.17,
+    value: 8,
+    valueRatio: 0.44,
   },
-  conservative: {
-    frameType: 'NORM',
-    id: 113,
-    newsAgencyName: '경향신문',
-    summary: '요약요약',
-    title: '기사 제목',
-  },
-  progressive: {
-    frameType: 'VALUE',
-    id: 6,
-    newsAgencyName: '경향신문',
-    summary: '요약요약',
-    title: '기사 제목',
-  },
+  bias: 44,
+  dominantFrameType: 'VALUE',
+  mainArticles: {
+    center: {
+      frameType: 'NEUTRAL',
+      id: 15,
+      newsAgencyName: '경향신문',
+      publishedAt: '2026-04-20',
+      summary: '요약요약dddd',
+      title: '기사 제목',
+    },
+    conservative: {
+      frameType: 'NORM',
+      id: 113,
+      newsAgencyName: '경향신문',
+      publishedAt: '2026-04-20',
+      summary: '요약요약',
+      title: '기사 제목',
+    },
+    progressive: {
+      frameType: 'STRONG_VALUE',
+      id: 5,
+      newsAgencyName: '경향신문',
+      publishedAt: '2026-04-20',
+      summary: '요약요약',
+      title: '기사 제목',
+    },
+  } satisfies ArticleSummarySectionTypes,
 };

--- a/src/mocks/data/scopeDetail.ts
+++ b/src/mocks/data/scopeDetail.ts
@@ -1,4 +1,4 @@
-import { type ArticleSummarySectionTypes } from '@/app/(main)/article/scope/[id]/types/articleSummarySection';
+import type { ScopeDetailTypes } from '@/app/(main)/article/scope/[id]/types/scopeDetailSection';
 
 export const SCOPE_DETAIL_MOCK = {
   id: 19,
@@ -43,5 +43,5 @@ export const SCOPE_DETAIL_MOCK = {
       summary: '요약요약',
       title: '기사 제목',
     },
-  } satisfies ArticleSummarySectionTypes,
-};
+  },
+} satisfies ScopeDetailTypes;


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #87 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- ScopeDetailBody 컴포넌트 생성
- ArticleSummarySection에서 목데이터 제거
- mainArticles를 props로 전달받아 렌더링하도록 수정

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
### ScopeDetailBody 컴포넌트 사용 방법
```ts
import ScopeDetailBody from './components/scopeDetailBody/ScopeDetailBody';

export default function ScopeArticlePage() {
  return (
    <ScopeDetailBody
      keywordName="고용노동부"
      keywordSummary="고용노동부 관련 주요 이슈와 기사 흐름을 요약한 내용입니다."
      articleCount={{
        neutral: 10,
        neutralRatio: 40,
        norm: 8,
        normRatio: 32,
        value: 7,
        valueRatio: 28,
      }}
      bias={44}
      dominantFrameType="VALUE"
    />
  );
}
```

**Props**
- `keywordName`: 주제 키워드 이름
- `keywordSummary`: 주제 키워드 요약 내용
- `articleCount`: 프레임 유형별 기사 개수 및 비율 정보
- `bias`: 편향도 수치
- `dominantFrameType`: 가장 기사 수가 많은 프레임 타입 (VALUE | NEUTRAL | NORM | BALANCED)

## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| Desktop | Tablet | Mobile |
|--|--|--|
| <img width="937" height="260" alt="스크린샷 2026-05-15 오후 3 31 29" src="https://github.com/user-attachments/assets/73f1fa64-64ef-423a-be33-d8760a41f4e3" /> | <img width="485" height="196" alt="스크린샷 2026-05-15 오후 3 31 51" src="https://github.com/user-attachments/assets/2d46bf3d-a9ab-44a8-9ee6-72ac3f28a55f" /> | <img width="333" height="342" alt="스크린샷 2026-05-15 오후 3 31 41" src="https://github.com/user-attachments/assets/bb359a4b-b1ce-44c0-b73b-848502c6f4b5" /> |

## 📚 Reference
<!-- 참고한 아티클 링크 / 새롭게 알게 된 점이 있다면 적어주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 스코프 상세 정보 표시 영역 추가

* **Refactor**
  * 컴포넌트가 동적 데이터를 props로 수신하도록 개선
  * Mock 데이터 구조 업데이트

* **Style**
  * 반응형 레이아웃 스타일링 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/team-balenz/balenz-client/pull/99)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->