### PR TITLE
[Feat] LinkDetailSection 컴포넌트 구현

### DIFF
--- a/src/app/(main)/article/link/[id]/components/linkDetailSection/LinkDetailSection.tsx
+++ b/src/app/(main)/article/link/[id]/components/linkDetailSection/LinkDetailSection.tsx
@@ -1,0 +1,32 @@
+import LinkDetailHeader from '../linkDetailHeader/LinkDetailHeader';
+import LinkDetailBody from '../linkDetailBody/LinkDetailBody';
+import ArticleDetailFooter from '@/app/(main)/article/components/articleDetailFooter/ArticleDetailFooter';
+
+import * as styles from './linkDetailSection.css';
+import { LINK_DETAIL_MOCK } from '@/mocks/data/linkDetail';
+
+const LinkDetailSection = () => {
+  return (
+    <div className={styles.container}>
+      <LinkDetailHeader
+        id={LINK_DETAIL_MOCK.id}
+        title={LINK_DETAIL_MOCK.title}
+        newsAgencyName={LINK_DETAIL_MOCK.newsAgencyName}
+        publishedAt={LINK_DETAIL_MOCK.publishedAt}
+        frameType={LINK_DETAIL_MOCK.frameType}
+        isScraped={LINK_DETAIL_MOCK.isScraped}
+      />
+      <div className={styles.bodyContainer}>
+        <LinkDetailBody
+          summary={LINK_DETAIL_MOCK.summary}
+          articleUrl={LINK_DETAIL_MOCK.articleUrl}
+        />
+      </div>
+      <div className={styles.footerContainer}>
+        <ArticleDetailFooter />
+      </div>
+    </div>
+  );
+};
+
+export default LinkDetailSection;

--- a/src/app/(main)/article/link/[id]/components/linkDetailSection/linkDetailSection.css.ts
+++ b/src/app/(main)/article/link/[id]/components/linkDetailSection/linkDetailSection.css.ts
@@ -1,0 +1,21 @@
+import { style } from '@vanilla-extract/css';
+import { media } from '@/shared/styles';
+
+export const container = style({
+  width: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+export const bodyContainer = style({
+  marginTop: '3.12rem',
+  '@media': {
+    [media.mobile]: {
+      marginTop: '1.88rem',
+    },
+  },
+});
+
+export const footerContainer = style({
+  marginTop: '3.12rem',
+});

--- a/src/app/(main)/article/link/[id]/types/linkDetailSection.ts
+++ b/src/app/(main)/article/link/[id]/types/linkDetailSection.ts
@@ -1,0 +1,12 @@
+import type { IdeologyIndicatorValueTypes } from '@/common/components/indicator/constants';
+
+export interface LinkDetailTypes {
+  id: number;
+  title: string;
+  newsAgencyName: string;
+  publishedAt: string;
+  frameType: IdeologyIndicatorValueTypes;
+  summary: string;
+  articleUrl: string;
+  isScraped: boolean;
+}

--- a/src/mocks/data/linkDetail.ts
+++ b/src/mocks/data/linkDetail.ts
@@ -1,0 +1,12 @@
+import type { LinkDetailTypes } from '@/app/(main)/article/link/[id]/types/linkDetailSection';
+
+export const LINK_DETAIL_MOCK = {
+  id: 5,
+  title: '기사 제목',
+  newsAgencyName: '경향신문',
+  publishedAt: '2026-04-20',
+  frameType: 'VALUE',
+  summary: '요약요약',
+  articleUrl: 'https://www.naver.com',
+  isScraped: false,
+} satisfies LinkDetailTypes;


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #100 

## ✨ Work Description
- Link 상세 페이지 구성을 위한 `LinkDetailSection` 컴포넌트를 생성했습니다.
- `LinkDetailHeader`, `LinkDetailBody`, `ArticleDetailFooter` 컴포넌트를 조합하여 화면이 렌더링되도록 구성했습니다.
- Link 상세 데이터 구조를 위한 `LinkDetailTypes` 타입을 정의했습니다.
- UI 확인 및 개발 편의를 위해 `LINK_DETAIL_MOCK` 목데이터를 추가했습니다.


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
```ts
import * as styles from './page.css';

import LinkDetailSection from './components/linkDetailSection/LinkDetailSection';

export default function LinkArticlePage() {
  return (
    <div className={styles.container}>
      <LinkDetailSection />
    </div>
  );
}
```

**설명**
- LinkDetailSection은 기사 상세 페이지 UI를 구성하는 상위 컴포넌트입니다.
- 페이지 컨테이너 내부에서 <LinkDetailSection /> 형태로 사용하면 됩니다.


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| Desktop | Tablet | Mobile |
|--|--|--|
| <img width="2306" height="1566" alt="image" src="https://github.com/user-attachments/assets/7e069ea2-cf6c-48f5-bba7-cd6539696453" /> | <img width="902" height="1298" alt="image" src="https://github.com/user-attachments/assets/8ec7a028-99c9-4899-bcce-36e2c32853e8" /> | <img width="640" height="1385" alt="image" src="https://github.com/user-attachments/assets/7b3e94cc-ed9d-428e-86b8-26ac4760312b" /> | 
