### PR TITLE
Feat: (scope) 주제 키워드 세부페이지 컴포넌트 조립 및 레이아웃 완성

### DIFF
--- a/src/app/(main)/article/scope/[id]/page.css.ts
+++ b/src/app/(main)/article/scope/[id]/page.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 
 import { boxStyle, media } from '@/shared/styles';
 
-export const container = style({
+export const scopeDetailLayout = style({
   width: '100%',
   padding: '5rem 5rem 8.25rem 5rem',
   '@media': {

--- a/src/app/(main)/article/scope/[id]/page.css.ts
+++ b/src/app/(main)/article/scope/[id]/page.css.ts
@@ -1,0 +1,71 @@
+import { style } from '@vanilla-extract/css';
+
+import { boxStyle, media } from '@/shared/styles';
+
+export const container = style({
+  width: '100%',
+  padding: '5rem 5rem 8.25rem 5rem',
+  '@media': {
+    [media.tablet]: {
+      padding: '2.5rem 2.5rem 11.75rem 2.5rem',
+    },
+
+    [media.mobile]: {
+      padding: '1.25rem 1.25rem 17rem 1.25rem',
+    },
+  },
+});
+
+export const topSection = style({
+  width: '100%',
+  display: 'grid',
+  gridTemplateColumns: '66.666% 33.333%',
+  columnGap: '1.5rem',
+  '@media': {
+    [media.belowDesktop]: {
+      gridTemplateColumns: '1fr',
+      rowGap: '6.25rem',
+    },
+  },
+});
+
+export const leftSection = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '6.06rem',
+  minWidth: 0,
+
+  '@media': {
+    [media.belowDesktop]: {
+      gap: '6.25rem',
+    },
+  },
+});
+
+export const rightSection = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.5rem',
+});
+
+export const reportSummaryWrapper = style({
+  '@media': {
+    [media.belowDesktop]: {
+      display: 'none',
+    },
+  },
+});
+
+export const adSection = style({
+  ...boxStyle,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  width: '100%',
+  height: '33.875rem',
+  '@media': {
+    [media.belowDesktop]: {
+      display: 'none',
+    },
+  },
+});

--- a/src/app/(main)/article/scope/[id]/page.tsx
+++ b/src/app/(main)/article/scope/[id]/page.tsx
@@ -10,7 +10,7 @@ import { SCOPE_DETAIL_MOCK } from '@/mocks/data/scopeDetail';
 
 export default function ScopeArticlePage() {
   return (
-    <div className={styles.container}>
+    <div className={styles.scopeDetailLayout}>
       <div className={styles.topSection}>
         <div className={styles.leftSection}>
           <ScopeDetailSection />

--- a/src/app/(main)/article/scope/[id]/page.tsx
+++ b/src/app/(main)/article/scope/[id]/page.tsx
@@ -1,3 +1,37 @@
+import * as styles from './page.css';
+
+import ScopeDetailSection from './components/scopeDetailSection/ScopeDetailSection';
+
+import RelatedArticleSection from '../../components/relatedArticleSection/RelatedArticleSection';
+import ReportSummarySection from '../../components/reportSummarySection/ReportSummarySection';
+import PopularScopeSection from '../../components/popularScopeSection/PopularScopeSection';
+
+import { SCOPE_DETAIL_MOCK } from '@/mocks/data/scopeDetail';
+
 export default function ScopeArticlePage() {
-  return <p>ScopeArticlePage</p>;
+  return (
+    <div className={styles.container}>
+      <div className={styles.topSection}>
+        <div className={styles.leftSection}>
+          <ScopeDetailSection />
+
+          <RelatedArticleSection />
+        </div>
+
+        <div className={styles.rightSection}>
+          <div className={styles.reportSummaryWrapper}>
+            <ReportSummarySection
+              articleCount={SCOPE_DETAIL_MOCK.articleCount}
+              bias={SCOPE_DETAIL_MOCK.bias}
+              dominantFrameType={SCOPE_DETAIL_MOCK.dominantFrameType}
+            />
+          </div>
+
+          <div className={styles.adSection}>파워링크 ad</div>
+
+          <PopularScopeSection />
+        </div>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #108 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
주제 키워드 세부페이지 레이아웃을 완성하고 반응형 그리드 구조를 구현했습니다.
- scopeDetailLayout: 5rem 기본 패딩으로 데스크톱 여유로운 구조 구성
- topSection: grid 기반 2단 레이아웃(66.666% / 33.333%)으로 desktop 뷰 구성 → tablet, mobile에서 단일 컬럼으로 자동 전환

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
### 그리드 레이아웃 구조
| 레이아웃 구조도 |
|--|
| <img width="577" height="469" alt="image" src="https://github.com/user-attachments/assets/84a1b7e1-e45c-4156-acc1-cfdb250bd7a2" /> |

- topSection → 2컬럼 그리드 (66.6% / 33.3%)
  - leftSection (왼쪽)
    🔵 ScopeDetailSection — 스코프 상세 + 성향별 기사 요약
    🟢 RelatedArticleSection — 연관기사 목록
  - rightSection (오른쪽)
    🟠 ReportSummarySection — 보도 세부사항 (총 뉴스 수, 편향 분포 등)
    🔴 adSection — 파워링크 광고
    🟣 PopularScopeSection — 인기 SCOPE 목록

→ belowDesktop 미디어 쿼리에서는 rightSection의 ReportSummarySection과 adSection이 display: none 처리되고, 전체가 1컬럼으로 바뀌는 반응형 구조

### 🗣️ 태블릿 뷰에서 PopularScopeSection 썸네일 이미지 크기 조정 필요 @leeeyez 
| 이슈 관련 이미지 |
|--|
| <img width="424" alt="image" src="https://github.com/user-attachments/assets/7685c07a-f9f5-4f85-a9a7-014fdbaa848c" /> |

- 현재 태블릿 뷰에서 썸네일 이미지 비율 및 크기가 디자인 대비 다소 어색하게 노출되고 있습니다.
- 태블릿 해상도 기준으로 이미지 크기 및 레이아웃 밸런스 확인 부탁드립니다.

### 🗣️ 데스크탑 뷰에서 ArticleDetailFooter 컴포넌트 우측 tooltip 위치 조정 필요 @ynzung 
| 이슈 관련 이미지 |
|--|
| <img width="500" alt="image" src="https://github.com/user-attachments/assets/729bd2ab-cc63-4ba3-b950-2c38d9e230a6" /> |

- 현재 ArticleDetailFooter의 우측 tooltip이 부모 컴포넌트인 ScopeDetailSection 영역 기준을 벗어나 노출되고 있습니다.
- 해당 부분 리팩토링 진행 후 반영하겠습니다.

## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| Desktop | Tablet | Mobile |
|--|--|--|
| <img width="2876" height="5992" alt="image" src="https://github.com/user-attachments/assets/94ec5673-1b6b-422c-983b-b2b86f2ad109" /> | <img width="902" height="4232" alt="image" src="https://github.com/user-attachments/assets/70153c2b-f45a-4120-a028-fd50b8f097a4" /> | <img width="902" height="4232" alt="image" src="https://github.com/user-attachments/assets/6d20747a-7a15-4efe-b787-517e5482debc" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 스코프 아티클 상세 페이지의 반응형 레이아웃을 구현했습니다. 데스크톱 환경에서는 좌측과 우측 섹션으로 구분되어 표시되며, 태블릿 및 모바일 환경에서는 콘텐츠 배치를 자동으로 조정합니다.

* **Refactor**
  * 스코프 아티클 상세 페이지를 완전히 재구성하여 관련 섹션 컴포넌트들을 통합 배치했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/team-balenz/balenz-client/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->