### PR TITLE
[Fix] ScopeArticleItem 이미지 비율 오류 조정 (tablet/large)

### DIFF
--- a/src/shared/components/scopeArticleItem/scopeArticleItem.css.ts
+++ b/src/shared/components/scopeArticleItem/scopeArticleItem.css.ts
@@ -58,7 +58,7 @@ export const imageWrapper = recipe({
     backgroundColor: color.brand.gray2,
 
     '@media': {
-      [media.belowDesktop]: {
+      [media.mobile]: {
         width: '6.25rem',
         height: '5rem',
       },
@@ -66,7 +66,14 @@ export const imageWrapper = recipe({
   },
   variants: {
     size: {
-      small: {}, // base 그대로
+      small: {
+        '@media': {
+          [media.tablet]: {
+            width: '6.25rem',
+            height: '5rem',
+          },
+        },
+      }, // base 그대로
       large: {
         '@media': {
           [media.tablet]: {


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #111 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
ScopeArticleItem 컴포넌트의 이미지 크기 반응형 CSS 오류를 수정했습니다.

1. `media.belowDesktop` → `media.mobile` 변경
   - 이전: tablet을 포함한 belowDesktop 쿼리가 size variant를 override하여 스타일 미적용
   - 현재: mobile만 별도 처리하여 tablet의 size variant 스타일 정상 적용

2. `size='small'` variant에 tablet 미디어 쿼리 추가
   - tablet에서: 6.25rem × 5rem (mobile과 동일 크기)

3. 디자인 의도 명확화
   - Desktop: 7rem × 5.625rem (기본)
   - Tablet small: 6.25rem × 5rem
   - Tablet large: 11.125rem × 6.25rem
   - Mobile: 6.25rem × 5rem


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
- CSS cascade 문제로 large 스타일이 정상 작동하지 않던 문제 해결
- PopularScopeSection에서 tablet일 때 `size='large'`로 표시되는 아이템들이 이제 올바른 이미지 크기로 렌더링됨


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 모바일 및 태블릿 환경에서 이미지 컨테이너의 반응형 레이아웃을 개선했습니다.
  * 모바일 기기에서 이미지 크기 표시를 최적화하고, 태블릿 화면에서의 이미지 렌더링 품질을 향상시켰습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/team-balenz/balenz-client/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->