### PR TITLE
Feat: (link) 아티클 링크 세부페이지 컴포넌트 조립 및 레이아웃 완성

### DIFF
--- a/src/app/(main)/(home)/page.css.ts
+++ b/src/app/(main)/(home)/page.css.ts
@@ -23,7 +23,7 @@ export const homeLayout = style({
 export const topSection = style({
   width: '100%',
   display: 'grid',
-  gridTemplateColumns: '66.666% 33.333%',
+  gridTemplateColumns: '2fr 1fr',
   gridTemplateAreas: `
     "scope right"
     "adDaily right"

--- a/src/app/(main)/article/link/[id]/page.css.ts
+++ b/src/app/(main)/article/link/[id]/page.css.ts
@@ -19,7 +19,7 @@ export const linkDetailLayout = style({
 export const container = style({
   width: '100%',
   display: 'grid',
-  gridTemplateColumns: '66.666% 33.333%',
+  gridTemplateColumns: '2fr 1fr',
   columnGap: '1.5rem',
   '@media': {
     [media.belowDesktop]: {

--- a/src/app/(main)/article/link/[id]/page.css.ts
+++ b/src/app/(main)/article/link/[id]/page.css.ts
@@ -1,0 +1,57 @@
+import { style } from '@vanilla-extract/css';
+
+import { boxStyle, media } from '@/shared/styles';
+
+export const linkDetailLayout = style({
+  width: '100%',
+  padding: '5rem 5rem 5.81rem 5rem',
+  '@media': {
+    [media.tablet]: {
+      padding: '2.5rem 2.5rem 8.75rem 2.5rem',
+    },
+
+    [media.mobile]: {
+      padding: '1.25rem 1.25rem 5.62rem 1.25rem',
+    },
+  },
+});
+
+export const container = style({
+  width: '100%',
+  display: 'grid',
+  gridTemplateColumns: '66.666% 33.333%',
+  columnGap: '1.5rem',
+  '@media': {
+    [media.belowDesktop]: {
+      gridTemplateColumns: '1fr',
+      rowGap: '6.25rem',
+    },
+  },
+});
+
+export const leftSection = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '6.25rem',
+  minWidth: 0,
+});
+
+export const rightSection = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.31rem',
+});
+
+export const adSection = style({
+  ...boxStyle,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  width: '100%',
+  height: '33.875rem',
+  '@media': {
+    [media.belowDesktop]: {
+      display: 'none',
+    },
+  },
+});

--- a/src/app/(main)/article/link/[id]/page.tsx
+++ b/src/app/(main)/article/link/[id]/page.tsx
@@ -1,3 +1,22 @@
+import * as styles from './page.css';
+
+import RelatedArticleSection from '../../components/relatedArticleSection/RelatedArticleSection';
+import LinkDetailSection from './components/linkDetailSection/LinkDetailSection';
+import PopularScopeSection from '../../components/popularScopeSection/PopularScopeSection';
+
 export default function LinkArticlePage() {
-  return <p>LinkArticlePage</p>;
+  return (
+    <div className={styles.linkDetailLayout}>
+      <div className={styles.container}>
+        <div className={styles.leftSection}>
+          <LinkDetailSection />
+          <RelatedArticleSection />
+        </div>
+        <div className={styles.rightSection}>
+          <div className={styles.adSection}>파워링크 ad</div>
+          <PopularScopeSection />
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/app/(main)/article/scope/[id]/page.css.ts
+++ b/src/app/(main)/article/scope/[id]/page.css.ts
@@ -16,7 +16,7 @@ export const scopeDetailLayout = style({
   },
 });
 
-export const topSection = style({
+export const container = style({
   width: '100%',
   display: 'grid',
   gridTemplateColumns: '66.666% 33.333%',

--- a/src/app/(main)/article/scope/[id]/page.css.ts
+++ b/src/app/(main)/article/scope/[id]/page.css.ts
@@ -19,7 +19,7 @@ export const scopeDetailLayout = style({
 export const container = style({
   width: '100%',
   display: 'grid',
-  gridTemplateColumns: '66.666% 33.333%',
+  gridTemplateColumns: '2fr 1fr',
   columnGap: '1.5rem',
   '@media': {
     [media.belowDesktop]: {

--- a/src/app/(main)/article/scope/[id]/page.tsx
+++ b/src/app/(main)/article/scope/[id]/page.tsx
@@ -11,7 +11,7 @@ import { SCOPE_DETAIL_MOCK } from '@/mocks/data/scopeDetail';
 export default function ScopeArticlePage() {
   return (
     <div className={styles.scopeDetailLayout}>
-      <div className={styles.topSection}>
+      <div className={styles.container}>
         <div className={styles.leftSection}>
           <ScopeDetailSection />
 


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #115 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
주제 키워드 세부페이지 레이아웃을 완성하고 반응형 그리드 구조를 구현했습니다.
- linkDetailLayout: 5rem 기본 패딩으로 데스크톱 여유로운 구조 구성
- container: grid 기반 2단 레이아웃(2fr / 1fr)으로 desktop 뷰 구성 → tablet, mobile에서 단일 컬럼으로 자동 전환
  - **home, scope 세부 페이지 모두 % 단위를 fr 단위로 변경하여 가로 오버플로우 수정했습니다.**

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
### 그리드 레이아웃 구조
| 레이아웃 구조도 |
|--|
| <img width="576" height="472" alt="스크린샷 2026-05-23 오후 9 39 50" src="https://github.com/user-attachments/assets/def979ce-b46c-44e8-926f-007aac3abf14" /> |

- container → 2컬럼 그리드 (2fr / 1fr)
  - leftSection (왼쪽)
    🔵 LinkDetailSection — 링크 상세 + 원문 보기 버튼
    🟢 RelatedArticleSection — 연관기사 목록
  - rightSection (오른쪽)
    🔴 adSection — 파워링크 광고
    🟣 PopularScopeSection — 인기 SCOPE 목록

→ belowDesktop 미디어 쿼리에서는 전체가 1컬럼으로 바뀌는 반응형 구조

## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| Desktop | Tablet | Mobile |
|--|--|--|
| <img width="2880" height="4170" alt="image" src="https://github.com/user-attachments/assets/94eb4a7c-4fcb-409f-8716-e4783bff27b4" /> | <img width="902" height="3322" alt="image" src="https://github.com/user-attachments/assets/86c15ae3-83b6-4573-ad38-8266a8ba8797" /> | <img width="608" height="4491" alt="image" src="https://github.com/user-attachments/assets/c2c6318d-03f1-4a5e-84c4-2704d189f292" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 링크 상세 페이지에 관련 기사 및 광고 영역을 포함한 다단계 레이아웃 구현
  * 태블릿 및 모바일 기기에 맞춘 반응형 디자인 추가

* **Style**
  * 기사 페이지의 레이아웃 스타일 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/team-balenz/balenz-client/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->