### PR TITLE
[Fix] 데스크탑 뷰 ArticleDetailFooter tooltip overflow 위치 수정

### DIFF
--- a/src/app/(main)/article/components/articleDetailFooter/ArticleDetailFooter.tsx
+++ b/src/app/(main)/article/components/articleDetailFooter/ArticleDetailFooter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import Image from 'next/image';
 
 import BaseTooltip from '@/shared/components/baseTooltip/BaseTooltip';
@@ -16,7 +16,22 @@ const ArticleDetailFooter = () => {
   const [isReportModalOpen, setIsReportModalOpen] = useState(false);
   const [openedTooltip, setOpenedTooltip] = useState<TooltipKey>(null);
 
+  // 툴팁을 부모 영역 기준으로 렌더링/위치 보정하기 위한 DOM 요소
+  const [tooltipBoundary, setTooltipBoundary] = useState<HTMLElement | null>(null);
+
+  // ArticleDetailFooter의 실제 부모 DOM을 boundary로 저장
+  const containerRef = useCallback((node: HTMLDivElement | null) => {
+    setTooltipBoundary(node?.parentElement ?? null);
+  }, []);
+
   const canHover = useCanHover();
+
+  const insightsTrigger = (
+    <div className={`${styles.tooltipContainer} ${styles.insightsTrigger}`}>
+      <Image src="/icons/ic_info.svg" alt="info" width={20} height={20} />
+      <p className={styles.tooltipText}>{TOOLTIP_TEXT.insights}</p>
+    </div>
+  );
 
   const reportTrigger = (
     <div
@@ -33,31 +48,34 @@ const ArticleDetailFooter = () => {
   );
 
   return (
-    <div className={styles.container}>
-      {/* insights tooltip (모바일에서도 터치로 열리게 유지) */}
-      <BaseTooltip
-        open={openedTooltip === 'insights'}
-        onOpenChange={(open) => setOpenedTooltip(open ? 'insights' : null)}
-        content={
-          <>
-            <span className={styles.insightsTooltipEmphasis}>
-              {TOOLTIP_CONTENT.insights.emphasizedWord}
-            </span>
-            {TOOLTIP_CONTENT.insights.body}
-          </>
-        }
-      >
-        <div className={`${styles.tooltipContainer} ${styles.insightsTrigger}`}>
-          <Image src="/icons/ic_info.svg" alt="info" width={20} height={20} />
-          <p className={styles.tooltipText}>{TOOLTIP_TEXT.insights}</p>
-        </div>
-      </BaseTooltip>
+    <div ref={containerRef} className={styles.container}>
+      {/* boundary가 준비된 뒤에만 Tooltip 적용 */}
+      {tooltipBoundary ? (
+        <BaseTooltip
+          open={openedTooltip === 'insights'}
+          onOpenChange={(open) => setOpenedTooltip(open ? 'insights' : null)}
+          collisionBoundary={tooltipBoundary}
+          content={
+            <>
+              <span className={styles.insightsTooltipEmphasis}>
+                {TOOLTIP_CONTENT.insights.emphasizedWord}
+              </span>
+              {TOOLTIP_CONTENT.insights.body}
+            </>
+          }
+        >
+          {insightsTrigger}
+        </BaseTooltip>
+      ) : (
+        insightsTrigger
+      )}
 
-      {/* problem tooltip (hover 가능한 환경에서만 tooltip 제공) */}
-      {canHover ? (
+      {/* hover 가능한 환경에서만 problem tooltip 제공 */}
+      {canHover && tooltipBoundary ? (
         <BaseTooltip
           open={openedTooltip === 'problem'}
           onOpenChange={(open) => setOpenedTooltip(open ? 'problem' : null)}
+          collisionBoundary={tooltipBoundary}
           content={TOOLTIP_CONTENT.problem}
         >
           {reportTrigger}

--- a/src/app/(main)/article/components/articleDetailFooter/ArticleDetailFooter.tsx
+++ b/src/app/(main)/article/components/articleDetailFooter/ArticleDetailFooter.tsx
@@ -26,13 +26,6 @@ const ArticleDetailFooter = () => {
 
   const canHover = useCanHover();
 
-  const insightsTrigger = (
-    <div className={`${styles.tooltipContainer} ${styles.insightsTrigger}`}>
-      <Image src="/icons/ic_info.svg" alt="info" width={20} height={20} />
-      <p className={styles.tooltipText}>{TOOLTIP_TEXT.insights}</p>
-    </div>
-  );
-
   const reportTrigger = (
     <div
       className={`${styles.tooltipContainer} ${styles.reportTrigger}`}
@@ -49,29 +42,28 @@ const ArticleDetailFooter = () => {
 
   return (
     <div ref={containerRef} className={styles.container}>
-      {/* boundary가 준비된 뒤에만 Tooltip 적용 */}
-      {tooltipBoundary ? (
-        <BaseTooltip
-          open={openedTooltip === 'insights'}
-          onOpenChange={(open) => setOpenedTooltip(open ? 'insights' : null)}
-          collisionBoundary={tooltipBoundary}
-          content={
-            <>
-              <span className={styles.insightsTooltipEmphasis}>
-                {TOOLTIP_CONTENT.insights.emphasizedWord}
-              </span>
-              {TOOLTIP_CONTENT.insights.body}
-            </>
-          }
-        >
-          {insightsTrigger}
-        </BaseTooltip>
-      ) : (
-        insightsTrigger
-      )}
+      {/* collisionBoundary optional 처리로 boundary 없이도 BaseTooltip 바로 렌더링 가능 */}
+      <BaseTooltip
+        open={openedTooltip === 'insights'}
+        onOpenChange={(open) => setOpenedTooltip(open ? 'insights' : null)}
+        collisionBoundary={tooltipBoundary}
+        content={
+          <>
+            <span className={styles.insightsTooltipEmphasis}>
+              {TOOLTIP_CONTENT.insights.emphasizedWord}
+            </span>
+            {TOOLTIP_CONTENT.insights.body}
+          </>
+        }
+      >
+        <div className={`${styles.tooltipContainer} ${styles.insightsTrigger}`}>
+          <Image src="/icons/ic_info.svg" alt="info" width={20} height={20} />
+          <p className={styles.tooltipText}>{TOOLTIP_TEXT.insights}</p>
+        </div>
+      </BaseTooltip>
 
       {/* hover 가능한 환경에서만 problem tooltip 제공 */}
-      {canHover && tooltipBoundary ? (
+      {canHover ? (
         <BaseTooltip
           open={openedTooltip === 'problem'}
           onOpenChange={(open) => setOpenedTooltip(open ? 'problem' : null)}

--- a/src/shared/components/baseTooltip/BaseTooltip.tsx
+++ b/src/shared/components/baseTooltip/BaseTooltip.tsx
@@ -11,13 +11,41 @@ interface BaseTooltipPropTypes {
   content: React.ReactNode;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  collisionBoundary: Element;
 }
 
-const BaseTooltip = ({ children, content, open, onOpenChange }: BaseTooltipPropTypes) => {
+const BaseTooltip = ({
+  children,
+  content,
+  open,
+  onOpenChange,
+  collisionBoundary,
+}: BaseTooltipPropTypes) => {
   const breakpoint = useMediaQuery();
-  const collisionPadding = breakpoint === 'desktop' ? 80 : breakpoint === 'tablet' ? 40 : 20;
-
   const isMobileOrTablet = breakpoint === 'mobile' || breakpoint === 'tablet';
+
+  const tooltipContent = (
+    <Tooltip.Content
+      className={styles.content}
+      side="top"
+      sideOffset={7}
+      // 툴팁 위치가 지정한 영역 밖으로 벗어나지 않도록 보정
+      collisionBoundary={collisionBoundary}
+      onPointerDownOutside={() => onOpenChange(false)}
+      onEscapeKeyDown={() => onOpenChange(false)}
+    >
+      {content}
+
+      <Tooltip.Arrow asChild width={27} height={15}>
+        <svg className={styles.arrow} viewBox="0 0 21 11" aria-hidden>
+          <path
+            className={styles.arrowPath}
+            d="M9.51854 10.5828C9.90572 10.9554 10.5181 10.9554 10.9053 10.5828L20.1152 1.72058C20.7639 1.09639 20.322 0 19.4218 0H1.00202C0.101813 0 -0.340024 1.09639 0.308646 1.72058L9.51854 10.5828Z"
+          />
+        </svg>
+      </Tooltip.Arrow>
+    </Tooltip.Content>
+  );
 
   return (
     <Tooltip.Provider delayDuration={200}>
@@ -27,37 +55,16 @@ const BaseTooltip = ({ children, content, open, onOpenChange }: BaseTooltipPropT
           onPointerDown={(e) => {
             if (!isMobileOrTablet) return;
 
-            // Radix가 focus 이벤트로 다시 열어버리는 걸 막음
+            // 모바일/태블릿에서는 터치로 tooltip toggle
             e.preventDefault();
-
-            // toggle
             onOpenChange(!open);
           }}
         >
           {children}
         </Tooltip.Trigger>
 
-        <Tooltip.Portal>
-          <Tooltip.Content
-            className={styles.content}
-            side="top"
-            sideOffset={7}
-            collisionPadding={collisionPadding}
-            onPointerDownOutside={() => onOpenChange(false)}
-            onEscapeKeyDown={() => onOpenChange(false)}
-          >
-            {content}
-
-            <Tooltip.Arrow asChild width={27} height={15}>
-              <svg className={styles.arrow} viewBox="0 0 21 11" aria-hidden>
-                <path
-                  className={styles.arrowPath}
-                  d="M9.51854 10.5828C9.90572 10.9554 10.5181 10.9554 10.9053 10.5828L20.1152 1.72058C20.7639 1.09639 20.322 0 19.4218 0H1.00202C0.101813 0 -0.340024 1.09639 0.308646 1.72058L9.51854 10.5828Z"
-                />
-              </svg>
-            </Tooltip.Arrow>
-          </Tooltip.Content>
-        </Tooltip.Portal>
+        {/* Tooltip.Content를 body가 아닌 지정한 부모 영역 내부에 렌더링 */}
+        <Tooltip.Portal container={collisionBoundary}>{tooltipContent}</Tooltip.Portal>
       </Tooltip.Root>
     </Tooltip.Provider>
   );

--- a/src/shared/components/baseTooltip/BaseTooltip.tsx
+++ b/src/shared/components/baseTooltip/BaseTooltip.tsx
@@ -11,7 +11,7 @@ interface BaseTooltipPropTypes {
   content: React.ReactNode;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  collisionBoundary: Element;
+  collisionBoundary?: Element | null;
 }
 
 const BaseTooltip = ({
@@ -30,7 +30,7 @@ const BaseTooltip = ({
       side="top"
       sideOffset={7}
       // 툴팁 위치가 지정한 영역 밖으로 벗어나지 않도록 보정
-      collisionBoundary={collisionBoundary}
+      collisionBoundary={collisionBoundary ?? undefined}
       onPointerDownOutside={() => onOpenChange(false)}
       onEscapeKeyDown={() => onOpenChange(false)}
     >
@@ -64,7 +64,7 @@ const BaseTooltip = ({
         </Tooltip.Trigger>
 
         {/* Tooltip.Content를 body가 아닌 지정한 부모 영역 내부에 렌더링 */}
-        <Tooltip.Portal container={collisionBoundary}>{tooltipContent}</Tooltip.Portal>
+        <Tooltip.Portal container={collisionBoundary ?? undefined}>{tooltipContent}</Tooltip.Portal>
       </Tooltip.Root>
     </Tooltip.Provider>
   );

--- a/src/shared/components/baseTooltip/baseTooltip.css.ts
+++ b/src/shared/components/baseTooltip/baseTooltip.css.ts
@@ -16,6 +16,7 @@ export const content = style({
     },
     [media.mobile]: {
       ...typography.phone.body2,
+      padding: '1.12rem 1.56rem',
     },
   },
 });


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #117 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
ArticleDetailFooter에서 사용하는 **BaseTooltip의 렌더링 기준을** document.body에서 **실제 부모 컨테이너로 변경**했습니다.

1. `Tooltip.Portal` container 변경
  - 이전: 기본값인 `document.body`에 마운트되어 툴팁 위치 보정이 전체 뷰포트 기준으로 계산됨
  - 현재: collisionBoundary로 전달받은 부모 DOM을 container로 지정하여 해당 영역 기준으로 마운트

2. BaseTooltip에 collisionBoundary prop 추가
  - `Tooltip.Portal`의 container와 `Tooltip.Content`의 collisionBoundary 모두에 적용하여 위치 계산 기준 통일
  - 기존 breakpoint별 collisionPadding 분기 제거 → 부모 영역을 기준으로 렌더되기 때문에 별도의 padding 설정 필요 X

3. ArticleDetailFooter에서 부모 DOM 참조
  - useCallback ref로 `node.parentElement`를 tooltipBoundary로 저장
  - tooltipBoundary 준비 전에는 trigger 요소만 렌더링되도록 조건부 처리


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
- tooltipBoundary 세팅 전 BaseTooltip 없이 trigger만 렌더링되는 타이밍이 존재하나, 마운트 직후 ref가 세팅되므로 실제 노출에는 영향 없음


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| 수정 전 | 수정 후 | 
|--|--|
| <img width="1440" height="778" alt="image" src="https://github.com/user-attachments/assets/aa74c5ae-df67-450c-ac68-59cd6393b7de" /> | <img width="1440" height="778" alt="image" src="https://github.com/user-attachments/assets/59be8699-2770-43f2-9ebf-ef481af72bcc" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 툴팁의 위치 계산 및 충돌 감지 로직을 개선하여 더 정확한 배치를 제공합니다
* 툴팁이 준비되기 전 오류 렌더링이 발생하던 문제를 수정했습니다
* 문제 보고 및 인사이트 툴팁의 표시 조건을 강화했습니다
* 툴팁 내부 여백을 최적화하여 시각적 가독성을 개선했습니다

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/team-balenz/balenz-client/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->