### PR TITLE
[Feat] 기사 Item 클릭 시 상세 페이지 이동 기능 추가

### DIFF
--- a/src/app/(main)/(home)/components/hotIssueSection/hotIssueArticleItem/HotIssueArticleItem.tsx
+++ b/src/app/(main)/(home)/components/hotIssueSection/hotIssueArticleItem/HotIssueArticleItem.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 
+import { ROUTES } from '@/shared/constants/route';
 import IdeologyIndicator from '@/common/components/indicator/IdeologyIndicator';
 import { type IdeologyIndicatorValueTypes } from '@/common/components/indicator/constants';
 
@@ -22,16 +24,14 @@ const HotIssueArticleItem = ({
   articleTitle,
   mediaName,
 }: HotIssueArticleItemPropTypes) => {
-  const handleClickArticle = () => {
-    console.log('[HotIssueArticleItem] 기사 상세 페이지로 이동 예정', { articleId });
-  };
+  const router = useRouter();
 
   return (
     <div
       className={styles.container}
       role="button"
       // tabIndex={0}
-      onClick={handleClickArticle}
+      onClick={() => router.push(ROUTES.LINK_DETAIL(articleId))}
       // onKeyDown={(e) => {
       //   if (e.key === 'Enter' || e.key === ' ') {
       //     e.preventDefault();

--- a/src/shared/components/articlePreviewItem/ArticlePreviewItem.tsx
+++ b/src/shared/components/articlePreviewItem/ArticlePreviewItem.tsx
@@ -1,9 +1,13 @@
 'use client';
 
-import * as styles from './articlePreviewItem.css';
+import { useRouter } from 'next/navigation';
+
+import { ROUTES } from '@/shared/constants/route';
 import IdeologyIndicator from '@/common/components/indicator/IdeologyIndicator';
 import { type IdeologyIndicatorResponsiveSizeTypes } from '@/common/components/indicator/types';
 import { type ArticlePreviewItemTypes } from '@/shared/types/articleItemType';
+
+import * as styles from './articlePreviewItem.css';
 
 /**
  * @description 기사 미리보기 아이템 컴포넌트에서 사용하는 기사 성향 아이콘 사이즈 매핑
@@ -18,17 +22,14 @@ const IDEOLOGY_INDICATOR_SIZE_BY_RENDER_TYPE: Record<
 };
 
 const ArticlePreviewItem = (props: ArticlePreviewItemTypes) => {
+  const router = useRouter();
   const { renderType, articleId, mediaName, articleTitle, frameType } = props;
-
-  const handleClickArticle = () => {
-    console.log('[ArticlePreviewItem] 기사 상세 페이지로 이동 예정', { articleId });
-  };
 
   return (
     <div
       className={styles.articlePreviewWrapper({ renderType })}
       role="button"
-      onClick={handleClickArticle}
+      onClick={() => router.push(ROUTES.LINK_DETAIL(articleId))}
     >
       <div className={styles.articleContentWrapper({ renderType })}>
         <div className={styles.metaRow}>

--- a/src/shared/components/scopeArticleItem/ScopeArticleItem.tsx
+++ b/src/shared/components/scopeArticleItem/ScopeArticleItem.tsx
@@ -1,10 +1,14 @@
 'use client';
 
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+
 import ScopePercentBar from '@/common/components/percentBar/ScopePercentBar';
+import { ROUTES } from '@/shared/constants/route';
 import { useMediaQuery } from '@/shared/hooks/useMediaQuery';
-import { IDEOLOGY_LABELS, PERCENT_BAR_SIZE_BY_ITEM_SIZE } from './constants';
 import type { ScopeArticleItemData } from '@/shared/components/scopeArticleItem/types';
+
+import { IDEOLOGY_LABELS, PERCENT_BAR_SIZE_BY_ITEM_SIZE } from './constants';
 import * as styles from './scopeArticleItem.css';
 
 interface ScopeArticleItemPropTypes extends ScopeArticleItemData {
@@ -12,6 +16,7 @@ interface ScopeArticleItemPropTypes extends ScopeArticleItemData {
 }
 
 const ScopeArticleItem = ({
+  keywordId,
   imageUrl,
   imageAlt,
   keyword,
@@ -21,6 +26,7 @@ const ScopeArticleItem = ({
   conservativeCount,
   size = 'small',
 }: ScopeArticleItemPropTypes) => {
+  const router = useRouter();
   const percentBarSize = PERCENT_BAR_SIZE_BY_ITEM_SIZE[size];
   const breakpoint = useMediaQuery();
 
@@ -33,7 +39,10 @@ const ScopeArticleItem = ({
     : `에 대해 ${IDEOLOGY_LABELS[ideology]} 관점으로 보도된 기사가 더 많습니다.`;
 
   return (
-    <div className={styles.container({ size })}>
+    <div
+      className={styles.container({ size })}
+      onClick={() => router.push(ROUTES.SCOPE_DETAIL(keywordId))}
+    >
       <div className={styles.contentWrapper}>
         {/* 이미지 */}
         <div className={styles.imageWrapper({ size })}>

--- a/src/shared/constants/route.ts
+++ b/src/shared/constants/route.ts
@@ -13,6 +13,8 @@ export const ROUTES = {
   JOIN: '/join',
   SEARCH: '/search',
   DAILY_FOCUS: '/daily-focus',
+  SCOPE_DETAIL: (id: number | string) => `/article/scope/${id}`,
+  LINK_DETAIL: (id: number | string) => `/article/link/${id}`,
 } as const;
 
 /**

--- a/src/shared/constants/route.ts
+++ b/src/shared/constants/route.ts
@@ -18,11 +18,11 @@ export const ROUTES = {
 } as const;
 
 /**
- * ROUTES의 값 중 하나가 될 수 있는 라우트 경로 타입
- * TypeScript 타입 안전성을 제공하여 잘못된 경로 값을 방지
+ * ROUTES에 정의된 정적 라우트 경로 문자열 타입
+ * 함수 형태의 동적 라우트는 제외하고 문자열 경로만 추출
  *
  * 사용 예시:
  * - 함수 파라미터: `function navigate(path: RoutePath) { ... }`
  * - 변수 선언: `const currentRoute: RoutePath = ROUTES.GLOBAL;`
  */
-export type RoutePath = (typeof ROUTES)[keyof typeof ROUTES];
+export type RoutePath = Extract<(typeof ROUTES)[keyof typeof ROUTES], string>;

--- a/src/shared/styles/global.css.ts
+++ b/src/shared/styles/global.css.ts
@@ -9,11 +9,6 @@ globalStyle('*, *::before, *::after', {
   boxSizing: 'border-box',
 });
 
-/* html 스타일 */
-globalStyle('html', {
-  scrollBehavior: 'smooth',
-});
-
 /* body 스타일 */
 globalStyle('body', {
   backgroundColor: color.brand.background,


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #126 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- 기사 Item 클릭 시 상세 페이지로 이동할 수 있도록 라우팅 연결
  -  `ArticlePreviewItem`, `HotIssueArticleItem`은 **Link 상세 페이지**로 이동하도록 구현
  - `ScopeArticleItem`은 **Scope 상세 페이지**로 이동하도록 구현
- 상세 페이지 이동을 위해 라우트 상수를 추가했습니다.
- ScopeArticleItem에서 keywordId에 따라 상세 페이지를 분기해야 하므로 관련 prop 추가

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
- ScopeArticleItem에서 상세 페이지 경로를 결정하기 위해 keywordId prop을 추가했습니다.
- 현재 Scope 상세 페이지 이동 경로는 keywordId를 기반으로 분기되도록 구현되어 있어 해당 값이 정상적으로 전달되는지 함께 확인 부탁드립니다



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 다양한 기사 항목에서 상세 페이지로의 직접 이동(링크/주제별 상세) 지원이 추가됨

* **Bug Fixes**
  * 기사 목록 및 관련 항목 클릭 시 상세 페이지로 올바르게 네비게이션되도록 개선됨

* **Style**
  * 전역 스크롤의 강제 애니메이션 동작(부드러운 스크롤) 제거됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->