### PR TITLE
[Feat] AuthHeader 컴포넌트 구현

### DIFF
--- a/public/logo/auth_logo.svg
+++ b/public/logo/auth_logo.svg
@@ -1,0 +1,4 @@
+<svg width="50" height="60" viewBox="0 0 50 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="49.7561" height="14.6341" rx="0.731707" fill="#1C232B"/>
+<circle cx="24.8781" cy="39.5122" r="20.4878" fill="#1C232B"/>
+</svg>

--- a/src/app/(auth)/components/authHeader/AuthHeader.tsx
+++ b/src/app/(auth)/components/authHeader/AuthHeader.tsx
@@ -1,0 +1,28 @@
+import Image from 'next/image';
+
+import * as styles from './authHeader.css';
+
+interface AuthHeaderProps {
+  title: string;
+  description: string;
+}
+
+const AuthHeader = ({ title, description }: AuthHeaderProps) => {
+  return (
+    <div className={styles.container}>
+      <Image
+        src="/logo/auth_logo.svg"
+        alt="Balenz 로고"
+        className={styles.logoImg}
+        width={50}
+        height={60}
+      />
+
+      <h1 className={styles.title}>{title}</h1>
+
+      {description && <p className={styles.description}>{description}</p>}
+    </div>
+  );
+};
+
+export default AuthHeader;

--- a/src/app/(auth)/components/authHeader/AuthHeader.tsx
+++ b/src/app/(auth)/components/authHeader/AuthHeader.tsx
@@ -2,12 +2,12 @@ import Image from 'next/image';
 
 import * as styles from './authHeader.css';
 
-interface AuthHeaderProps {
+interface AuthHeaderPropTypes {
   title: string;
   description: string;
 }
 
-const AuthHeader = ({ title, description }: AuthHeaderProps) => {
+const AuthHeader = ({ title, description }: AuthHeaderPropTypes) => {
   return (
     <div className={styles.container}>
       <Image

--- a/src/app/(auth)/components/authHeader/authHeader.css.ts
+++ b/src/app/(auth)/components/authHeader/authHeader.css.ts
@@ -1,0 +1,49 @@
+import { style } from '@vanilla-extract/css';
+import { color, media, typography } from '@/shared/styles';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+export const logoImg = style({
+  marginBottom: '0.94rem',
+  paddingLeft: '0.37rem',
+  '@media': {
+    [media.tablet]: {
+      paddingLeft: '0.38rem',
+    },
+    [media.mobile]: {
+      paddingLeft: '0.04rem',
+    },
+  },
+});
+
+export const title = style({
+  ...typography.correction,
+  ...typography.desktop.display,
+  color: color.text.main,
+  marginBottom: '0.19rem',
+  '@media': {
+    [media.tablet]: {
+      ...typography.tablet.display,
+    },
+    [media.mobile]: {
+      ...typography.phone.display,
+    },
+  },
+});
+
+export const description = style({
+  ...typography.correction,
+  ...typography.desktop.h3,
+  color: color.text.disabled,
+  '@media': {
+    [media.tablet]: {
+      ...typography.tablet.h3,
+    },
+    [media.mobile]: {
+      ...typography.phone.h3,
+    },
+  },
+});


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #134 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- 인증 페이지 공통 헤더 컴포넌트(AuthHeader) 구현
  - 로고, 제목, 설명 문구를 Props로 받아 로그인/회원가입 등 인증 관련 페이지에서 재사용할 수 있도록 구성했습니다.
  - 반응형 환경에 맞춰 Typography 스타일을 적용했습니다.
  - 디바이스별 로고 위치 및 텍스트 스타일을 설정했습니다.


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
### AuthHeader
- 로그인, 회원가입 등 인증 페이지의 헤더 UI를 담당하는 공통 컴포넌트입니다.

#### 사용 예시
```ts
import AuthHeader from '../components/authHeader/AuthHeader';

export default function LoginPage() {
  return (
    <AuthHeader
      title="로그인하기"
      description="Balenz에 오신 것을 환영합니다"
    />
  );
}
```

## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| 구현 이미지 |
|--|
| <img width="253" height="144" alt="스크린샷 2026-06-12 오전 12 35 26" src="https://github.com/user-attachments/assets/64a08547-8d3d-4e59-9a72-65c54d83487d" /> |



## 📚 Reference
<!-- 참고한 아티클 링크 / 새롭게 알게 된 점이 있다면 적어주세요. -->
