### PR TITLE
[Refactor] ArticlePreviewItem 확장 (search 타입)

### DIFF
--- a/src/shared/components/articlePreviewItem/ArticlePreviewItem.tsx
+++ b/src/shared/components/articlePreviewItem/ArticlePreviewItem.tsx
@@ -19,6 +19,7 @@ const IDEOLOGY_INDICATOR_SIZE_BY_RENDER_TYPE: Record<
   default: { desktop: 'medium', tablet: 'medium', mobile: 'medium' },
   compact: { desktop: 'small', tablet: 'small', mobile: 'extraSmall' },
   expanded: { desktop: 'medium', tablet: 'medium', mobile: 'medium' },
+  search: { desktop: 'medium', tablet: 'medium', mobile: 'medium' },
 };
 
 const ArticlePreviewItem = (props: ArticlePreviewItemTypes) => {

--- a/src/shared/components/articlePreviewItem/articlePreviewItem.css.ts
+++ b/src/shared/components/articlePreviewItem/articlePreviewItem.css.ts
@@ -36,6 +36,17 @@ export const articlePreviewWrapper = recipe({
         padding: '1.25rem 0 2.19rem',
         gap: '0.5rem',
       },
+      search: {
+        padding: '0.94rem 1.25rem 0.94rem 0.31rem',
+        gap: '0.5rem',
+
+        '@media': {
+          [media.belowDesktop]: {
+            padding: '0.62rem 1.25rem 0.62rem 0.31rem',
+            gap: '0.5rem',
+          },
+        },
+      },
     },
   },
 
@@ -67,6 +78,7 @@ export const articleContentWrapper = recipe({
         },
       },
       expanded: {},
+      search: {},
     },
   },
 
@@ -148,6 +160,9 @@ export const articleTitle = recipe({
             WebkitLineClamp: 2,
           },
         },
+      },
+      search: {
+        WebkitLineClamp: 1,
       },
     },
   },

--- a/src/shared/components/articlePreviewItem/articlePreviewItem.css.ts
+++ b/src/shared/components/articlePreviewItem/articlePreviewItem.css.ts
@@ -162,7 +162,17 @@ export const articleTitle = recipe({
         },
       },
       search: {
+        ...typography.correction,
+        ...typography.desktop.h4,
         WebkitLineClamp: 1,
+        '@media': {
+          [media.tablet]: {
+            ...typography.tablet.h4,
+          },
+          [media.mobile]: {
+            ...typography.phone.h3,
+          },
+        },
       },
     },
   },

--- a/src/shared/types/articleItemType.ts
+++ b/src/shared/types/articleItemType.ts
@@ -1,7 +1,7 @@
 // articleItemType.ts
 import { type IdeologyIndicatorValueTypes } from '@/common/components/indicator/constants';
 
-// 아티클 아이템 기본 공통 타입 (default, compact, expanded 모두 사용)
+// 아티클 아이템 기본 공통 타입 (default, compact, expanded, search 모두 사용)
 export interface ArticleBaseTypes {
   articleId: number;
   mediaName: string;
@@ -32,8 +32,14 @@ export interface ExpandedArticlePreviewItemTypes
   renderType: 'expanded';
 }
 
+// search 결과 타입 아이템 타입
+export interface SearchArticlePreviewItemTypes extends ArticleBaseTypes {
+  renderType: 'search';
+}
+
 // 아이템 타입 유니온 타입
 export type ArticlePreviewItemTypes =
   | DefaultArticlePreviewItemTypes
   | CompactArticlePreviewItemTypes
-  | ExpandedArticlePreviewItemTypes;
+  | ExpandedArticlePreviewItemTypes
+  | SearchArticlePreviewItemTypes;


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #132 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- `ArticlePreviewItem`에 검색 결과용 `search` renderType을 추가했습니다.
- `ArticlePreviewItemTypes` 유니온 타입에 `SearchArticlePreviewItemTypes`를 추가해 검색 결과 아이템 타입을 분리했습니다.
- `search` 타입에서 사용하는 `IdeologyIndicator` 반응형 사이즈 매핑을 추가했습니다.
- `articlePreviewItem.css.ts`에 `search` 타입 전용 스타일을 추가했습니다.
  - 검색 결과 리스트에 맞는 padding 적용
  - below desktop 구간 padding 조정
  - 기사 제목을 1줄 말줄임 처리


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
- `search` 타입은 현재 `ArticleBaseTypes`만 확장해서 사용하며, 발행일/요약은 포함하지 않습니다.
- `search` 타입의 indicator size는 현재 desktop/tablet/mobile 모두 `medium`으로 지정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 검색 결과 페이지에서 기사 항목의 표시 형식이 최적화되었습니다. 새로운 레이아웃에서 제목 표시 줄 수가 조정되고 여백과 간격이 검색 결과에 맞게 설정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->