### PR TITLE
[Refactor] DefaultButton 컴포넌트 확장

### DIFF
--- a/src/common/components/defaultButton/DefaultButton.tsx
+++ b/src/common/components/defaultButton/DefaultButton.tsx
@@ -7,6 +7,7 @@ interface DefaultButtonPropTypes {
   onClick?: () => void;
   disabled?: boolean;
   type?: 'button' | 'submit' | 'reset';
+  variant?: 'default' | 'auth';
 }
 
 const DefaultButton = ({
@@ -14,9 +15,15 @@ const DefaultButton = ({
   onClick,
   disabled = false,
   type = 'button',
+  variant = 'default',
 }: DefaultButtonPropTypes) => {
   return (
-    <button className={styles.defaultButton} onClick={onClick} disabled={disabled} type={type}>
+    <button
+      className={styles.defaultButton({ variant })}
+      onClick={onClick}
+      disabled={disabled}
+      type={type}
+    >
       {label}
     </button>
   );

--- a/src/common/components/defaultButton/defaultButton.css.ts
+++ b/src/common/components/defaultButton/defaultButton.css.ts
@@ -1,32 +1,60 @@
-import { style } from '@vanilla-extract/css';
-import { media } from '@/shared/styles/media';
-import { color, typography } from '@/shared/styles';
+import { recipe } from '@vanilla-extract/recipes';
+import { color, typography, media } from '@/shared/styles';
 
-export const defaultButton = style({
-  ...typography.desktop.body2,
-  display: 'flex',
-  padding: '0.625rem 0.9375rem',
-  justifyContent: 'center',
-  alignItems: 'center',
-  gap: '0.625rem',
-  borderRadius: '0.3125rem',
-  backgroundColor: color.brand.main,
-  color: color.brand.background,
-  border: 'none',
-  cursor: 'pointer',
-  transition: 'background-color 0.2s ease',
+export const defaultButton = recipe({
+  base: {
+    ...typography.correction,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: '0.625rem',
+    borderRadius: '0.3125rem',
+    backgroundColor: color.brand.main,
+    color: color.brand.background,
+    border: 'none',
+    cursor: 'pointer',
+    transition: 'background-color 0.2s ease',
 
-  ':disabled': {
-    backgroundColor: color.text.disabled,
-    cursor: 'not-allowed',
+    ':disabled': {
+      backgroundColor: color.brand.gray2,
+      cursor: 'not-allowed',
+    },
   },
 
-  '@media': {
-    [media.tablet]: {
-      ...typography.tablet.body2,
+  variants: {
+    variant: {
+      default: {
+        ...typography.desktop.body2,
+        padding: '0.625rem 0.9375rem',
+
+        '@media': {
+          [media.tablet]: {
+            ...typography.tablet.body2,
+          },
+          [media.mobile]: {
+            ...typography.phone.button,
+          },
+        },
+      },
+
+      auth: {
+        ...typography.desktop.h4,
+        width: '100%',
+        height: '3.125rem',
+
+        '@media': {
+          [media.tablet]: {
+            ...typography.tablet.h4,
+          },
+          [media.mobile]: {
+            ...typography.phone.h3,
+          },
+        },
+      },
     },
-    [media.mobile]: {
-      ...typography.phone.button,
-    },
+  },
+
+  defaultVariants: {
+    variant: 'default',
   },
 });


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #145 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- DefaultButton에 variant 기반 스타일 분기 구조 적용
  - 인증 화면에서 사용할 auth variant 추가
  - auth variant에 로그인/회원가입 버튼 디자인(높이, 타이포그래피, 전체 너비) 반영
  - 기존 버튼 스타일은 default variant로 유지
  - style에서 recipe 기반 구조로 변경하여 버튼 스타일 확장이 가능하도록 개선

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
- 기존 DefaultButton 사용처는 별도 수정 없이 그대로 동작합니다.
- `variant="auth"`를 전달하면 로그인/회원가입 화면에서 사용하는 버튼 스타일이 적용됩니다.

## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| Desktop | Tablet | Mobile |
|-|--|--|
| <img width="1440" height="334" alt="스크린샷 2026-06-15 오전 12 20 09" src="https://github.com/user-attachments/assets/d830e1aa-4a44-4b17-829c-c78769d56409" /> | <img width="449" height="186" alt="스크린샷 2026-06-15 오전 12 20 46" src="https://github.com/user-attachments/assets/534057b9-5a06-4b77-becf-36411034c11a" /> | <img width="304" height="229" alt="스크린샷 2026-06-15 오전 12 20 33" src="https://github.com/user-attachments/assets/d736cf85-1d98-484a-b67d-9c3915631483" /> |
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일 개선**
  * 기본 버튼 컴포넌트에 시각적 변형(variant) 옵션 추가: 기본 스타일과 인증 스타일 지원
  * 반응형 디자인 개선으로 데스크탑, 태블릿, 모바일에서의 일관된 표현 강화
  * 비활성화된 버튼의 시각적 피드백 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->