### PR TITLE
[Feat] SearchPagenation 컴포넌트 구현

### DIFF
--- a/public/icons/ic_pagenation_next.svg
+++ b/public/icons/ic_pagenation_next.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9 18L15 12L9 6" stroke="#1E1E1E" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/ic_pagenation_prev.svg
+++ b/public/icons/ic_pagenation_prev.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15 18L9 12L15 6" stroke="#1E1E1E" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/app/(main)/search/components/searchPagenation/SearchPagenation.tsx
+++ b/src/app/(main)/search/components/searchPagenation/SearchPagenation.tsx
@@ -1,0 +1,79 @@
+import Image from 'next/image';
+import * as styles from './searchPagenation.css';
+
+interface SearchPagenationPropTypes {
+  currentPage?: number;
+  totalPages?: number;
+  onPageChange?: (page: number) => void;
+}
+
+const SearchPagenation = ({
+  currentPage = 1,
+  totalPages = 5,
+  onPageChange,
+}: SearchPagenationPropTypes) => {
+  const pages = Array.from({ length: totalPages }, (_, index) => index + 1);
+  const canGoPrev = currentPage > 1;
+  const canGoNext = currentPage < totalPages;
+
+  const handlePageChange = (page: number) => {
+    if (page === currentPage) return;
+    onPageChange?.(page);
+  };
+
+  return (
+    <nav className={styles.wrapper} aria-label="검색 결과 페이지네이션">
+      <button
+        type="button"
+        className={styles.arrowButton}
+        onClick={() => handlePageChange(currentPage - 1)}
+        disabled={!canGoPrev}
+        aria-label="이전 페이지"
+      >
+        <Image
+          src="/icons/ic_pagenation_prev.svg"
+          alt=""
+          width={24}
+          height={24}
+          className={styles.arrowIcon}
+          aria-hidden
+        />
+      </button>
+
+      <ol className={styles.pageList}>
+        {pages.map((page) => (
+          <li key={page}>
+            <button
+              type="button"
+              className={styles.pageButton({ active: page === currentPage })}
+              onClick={() => handlePageChange(page)}
+              aria-current={page === currentPage ? 'page' : undefined}
+              aria-label={`${page} 페이지`}
+            >
+              {page}
+            </button>
+          </li>
+        ))}
+      </ol>
+
+      <button
+        type="button"
+        className={styles.arrowButton}
+        onClick={() => handlePageChange(currentPage + 1)}
+        disabled={!canGoNext}
+        aria-label="다음 페이지"
+      >
+        <Image
+          src="/icons/ic_pagenation_next.svg"
+          alt=""
+          width={24}
+          height={24}
+          className={styles.arrowIcon}
+          aria-hidden
+        />
+      </button>
+    </nav>
+  );
+};
+
+export default SearchPagenation;

--- a/src/app/(main)/search/components/searchPagenation/searchPagenation.css.ts
+++ b/src/app/(main)/search/components/searchPagenation/searchPagenation.css.ts
@@ -1,0 +1,97 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+import { color, media, typography } from '@/shared/styles';
+
+export const wrapper = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '3.12rem',
+  width: '100%',
+});
+
+export const pageList = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.31rem',
+  margin: 0,
+  padding: 0,
+  listStyle: 'none',
+});
+
+export const pageButton = recipe({
+  base: {
+    ...typography.correction,
+    ...typography.desktop.body3,
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '1.875rem',
+    height: '1.875rem',
+    padding: 0,
+    border: 'none',
+    background: 'transparent',
+    color: color.text.main,
+    cursor: 'pointer',
+
+    '@media': {
+      [media.tablet]: {
+        ...typography.tablet.body3,
+      },
+      [media.mobile]: {
+        ...typography.phone.body3,
+      },
+    },
+
+    ':focus-visible': {
+      outline: `0.125rem solid ${color.brand.main}`,
+      outlineOffset: '0.25rem',
+    },
+  },
+  variants: {
+    active: {
+      true: {
+        '::after': {
+          content: '',
+          position: 'absolute',
+          left: '50%',
+          bottom: 0,
+          width: '1.875rem',
+          height: '0.125rem',
+          transform: 'translateX(-50%)',
+          backgroundColor: color.brand.main,
+        },
+      },
+      false: {},
+    },
+  },
+});
+
+export const arrowButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '1.5rem',
+  height: '1.5rem',
+  padding: 0,
+  border: 'none',
+  background: 'transparent',
+  cursor: 'pointer',
+
+  ':disabled': {
+    cursor: 'default',
+    opacity: 0.35,
+  },
+
+  ':focus-visible': {
+    outline: `0.125rem solid ${color.brand.main}`,
+    outlineOffset: '0.25rem',
+  },
+});
+
+export const arrowIcon = style({
+  display: 'block',
+  width: '1.5rem',
+  height: '1.5rem',
+});

--- a/src/app/(main)/search/components/searchResultContent/newsResultList/NewsResultList.tsx
+++ b/src/app/(main)/search/components/searchResultContent/newsResultList/NewsResultList.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import * as styles from './newsResultList.css';
+
+import ArticlePreviewItem from '@/shared/components/articlePreviewItem/ArticlePreviewItem';
+import type { SearchArticlePreviewItemTypes } from '@/shared/types/articleItemType';
+
+interface NewsListPropTypes {
+  items: SearchArticlePreviewItemTypes[];
+}
+
+const NewsList = ({ items }: NewsListPropTypes) => {
+  return (
+    <section className={styles.section}>
+      <div className={styles.tabsContainer}></div>
+      <div className={styles.articlesContainer}>
+        {items.map((article) => (
+          <div key={article.articleId} className={styles.articleItem}>
+            <ArticlePreviewItem {...article} />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default NewsList;

--- a/src/app/(main)/search/components/searchResultContent/newsResultList/NewsResultList.tsx
+++ b/src/app/(main)/search/components/searchResultContent/newsResultList/NewsResultList.tsx
@@ -12,13 +12,14 @@ interface NewsListPropTypes {
 const NewsList = ({ items }: NewsListPropTypes) => {
   return (
     <section className={styles.section}>
-      <div className={styles.tabsContainer}></div>
-      <div className={styles.articlesContainer}>
-        {items.map((article) => (
-          <div key={article.articleId} className={styles.articleItem}>
-            <ArticlePreviewItem {...article} />
-          </div>
-        ))}
+      <div className={styles.tabsContainer}>
+        <div className={styles.articlesContainer}>
+          {items.map((article) => (
+            <div key={article.articleId} className={styles.articleItem}>
+              <ArticlePreviewItem {...article} />
+            </div>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/src/app/(main)/search/components/searchResultContent/newsResultList/newsResultList.css.ts
+++ b/src/app/(main)/search/components/searchResultContent/newsResultList/newsResultList.css.ts
@@ -1,0 +1,40 @@
+import { style } from '@vanilla-extract/css';
+import { media } from '@/shared/styles';
+
+export const section = style({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+export const tabsContainer = style({
+  width: '100%',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  '@media': {
+    [media.tablet]: {
+      flexDirection: 'column',
+      alignItems: 'flex-start',
+      justifyContent: 'flex-start',
+    },
+    [media.mobile]: {
+      flexDirection: 'column',
+      alignItems: 'flex-start',
+      justifyContent: 'flex-start',
+    },
+  },
+});
+
+export const articlesContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.625rem',
+
+  '@media': {
+    [media.mobile]: {
+      gap: '0.31rem',
+    },
+  },
+});
+
+export const articleItem = style({});

--- a/src/app/(main)/search/components/searchResultContent/scopeResultList/ScopeResultList.tsx
+++ b/src/app/(main)/search/components/searchResultContent/scopeResultList/ScopeResultList.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import * as styles from './scopeResultList.css';
+
+import ScopeArticleItem from '@/shared/components/scopeArticleItem/ScopeArticleItem';
+import type { ScopeArticleItemData } from '@/shared/components/scopeArticleItem/types';
+
+interface ScopeResultListPropTypes {
+  items: ScopeArticleItemData[];
+}
+
+const ScopeResultList = ({ items }: ScopeResultListPropTypes) => {
+  return (
+    <section className={styles.section}>
+      <ul className={styles.articlesContainer}>
+        {items.map((article) => (
+          <li key={article.id} className={styles.articleItem}>
+            <ScopeArticleItem {...article} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export default ScopeResultList;

--- a/src/app/(main)/search/components/searchResultContent/scopeResultList/scopeResultList.css.ts
+++ b/src/app/(main)/search/components/searchResultContent/scopeResultList/scopeResultList.css.ts
@@ -1,0 +1,24 @@
+import { style } from '@vanilla-extract/css';
+import { media } from '@/shared/styles';
+
+export const section = style({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+export const articlesContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.62rem',
+  margin: 0,
+  padding: 0,
+  listStyle: 'none',
+
+  '@media': {
+    [media.mobile]: {
+      gap: '0.31rem',
+    },
+  },
+});
+
+export const articleItem = style({});


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #149 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- 검색 결과 페이지에서 사용할 `SearchPagenation` 컴포넌트 구현
- 페이지 번호, 이전/다음 버튼, 현재 페이지 underline UI 구성
- 페이지네이션 전용 스타일 파일 `searchPagenation.css.ts` 추가
- 이전/다음 화살표 아이콘 추가
  - `ic_pagenation_prev.svg`
  - `ic_pagenation_next.svg`
- `currentPage`, `totalPages`, `onPageChange` props 기반으로 외부에서 페이지 상태를 제어할 수 있도록 구현

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
```tsx
<SearchPagenation
  currentPage={currentPage}
  totalPages={totalPages}
  onPageChange={setCurrentPage}
/>
```

#### Props
- `currentPage?: number`
   - 현재 활성화된 페이지 번호입니다.
   - 기본값은 1입니다.
- `totalPages?: number`
   - 렌더링할 전체 페이지 수입니다.
   - 기본값은 5입니다.
- `onPageChange?: (page: number) => void`
   - 페이지 번호 또는 이전/다음 버튼 클릭 시 호출됩니다.

#### 페이지네이션 로직
- totalPages 값을 기준으로 1부터 totalPages까지 페이지 배열을 생성합니다.
```ts
const pages = Array.from({ length: totalPages }, (_, index) => index + 1);
```
- 이전 버튼은 currentPage > 1일 때만 활성화됩니다.
```ts
const canGoPrev = currentPage > 1;
```
- 다음 버튼은 currentPage < totalPages일 때만 활성화됩니다.
```ts
const canGoNext = currentPage < totalPages;
```
- 현재 페이지와 같은 페이지를 다시 클릭한 경우에는 불필요한 상태 업데이트를 막기 위해 onPageChange를 호출하지 않습니다.
```ts
const handlePageChange = (page: number) => {
  if (page === currentPage) return;
  onPageChange?.(page);
};
```
- 이전 버튼 클릭 시 currentPage - 1, 다음 버튼 클릭 시 currentPage + 1 값을 전달합니다. 
- 현재 페이지 버튼에는 aria-current="page"를 부여하고, 스타일 variant로 underline을 표시합니다.
- 첫 페이지/마지막 페이지에서는 각각 이전/다음 버튼이 disabled 처리됩니다.

#### 데이터 처리
- 해당 컴포넌트는 직접 데이터를 자르거나 필터링하지 않습니다.
- 실제 item slicing은 상위 검색 페이지에서 처리하고, SearchPagenation은 페이지 번호 변경 이벤트만 담당합니다.

_* 페이지네이션 기능과 디자인이 단순하여, 라이브러리 쓰면 오히려 커스텀 비용이 더 커질 가능성이 높기 때문에 직접 구현하는 방식을 선택했습니다._

## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
<img width="246" height="55" alt="스크린샷 2026-06-15 오후 10 52 32" src="https://github.com/user-attachments/assets/e1fb8a8d-21dc-4ce5-ab46-98d94ef29e3d" />
