### PR TITLE
[Feat] ideology 공통 타입 선언

### DIFF
--- a/src/app/(main)/(home)/components/ByIdeologySection/ByIdeologyHeader/ByIdeologyHeader.tsx
+++ b/src/app/(main)/(home)/components/ByIdeologySection/ByIdeologyHeader/ByIdeologyHeader.tsx
@@ -8,25 +8,21 @@ interface ByIdeologyHeaderPropTypes {
 }
 
 const IDEOLOGY_MAPPING_TITLE = {
-  progressive: '진보 성향 기사',
-  center: '중도 성향 기사',
-  conservative: '보수 성향 기사',
+  VALUE: '진보 성향 기사',
+  NEUTRAL: '중도 성향 기사',
+  NORM: '보수 성향 기사',
 } as const;
 
 const IDEOLOGY_COLOR_THEME = {
-  progressive: color.brand.progressive,
-  center: color.brand.center,
-  conservative: color.brand.conservative,
+  VALUE: color.brand.progressive,
+  NEUTRAL: color.brand.center,
+  NORM: color.brand.conservative,
 } as const;
 
 const ByIdeologyHeader = ({ ideology }: ByIdeologyHeaderPropTypes) => {
-  const headerColor = IDEOLOGY_COLOR_THEME[ideology] ?? IDEOLOGY_COLOR_THEME.center;
-
   return (
-    <div className={styles.container} style={{ backgroundColor: headerColor }}>
-      <p className={styles.title}>
-        {IDEOLOGY_MAPPING_TITLE[ideology] ?? IDEOLOGY_MAPPING_TITLE.center}
-      </p>
+    <div className={styles.container} style={{ backgroundColor: IDEOLOGY_COLOR_THEME[ideology] }}>
+      <p className={styles.title}>{IDEOLOGY_MAPPING_TITLE[ideology]}</p>
     </div>
   );
 };

--- a/src/app/(main)/(home)/components/ByIdeologySection/ByIdeologyHeader/ByIdeologyHeader.tsx
+++ b/src/app/(main)/(home)/components/ByIdeologySection/ByIdeologyHeader/ByIdeologyHeader.tsx
@@ -1,9 +1,10 @@
 import { color } from '@/shared/styles/color.css';
+import { BaseFrameType } from '@/shared/types/frame';
 
 import * as styles from './byIdeologyHeader.css';
 
 interface ByIdeologyHeaderPropTypes {
-  ideology: 'progressive' | 'center' | 'conservative';
+  ideology: BaseFrameType;
 }
 
 const IDEOLOGY_MAPPING_TITLE = {

--- a/src/app/(main)/(home)/components/ByIdeologySection/ByIdeologySection.tsx
+++ b/src/app/(main)/(home)/components/ByIdeologySection/ByIdeologySection.tsx
@@ -12,7 +12,7 @@ import ByIdeologyGroup from './ByIdeologyGroup/ByIdeologyGroup';
 import * as styles from './byIdeologySection.css';
 
 const ByIdeologySection = () => {
-  const [activeKey, setActiveKey] = useState<string>('progressive');
+  const [activeKey, setActiveKey] = useState<string>('VALUE');
 
   const isMobile = useMediaQuery() === 'mobile';
 

--- a/src/app/(main)/(home)/components/hotArticleSection/hotArticleGroup/HotArticleGroup.tsx
+++ b/src/app/(main)/(home)/components/hotArticleSection/hotArticleGroup/HotArticleGroup.tsx
@@ -30,7 +30,7 @@ const HotArticleGroup = ({ ideology, articleItems }: HotArticleSectionGroupTypes
   return (
     <div className={styles.group}>
       <div className={styles.ideologyLabel({ ideology })}>
-        {ideology === 'progressive' ? '진보 독자' : '보수 독자'}
+        {ideology === 'VALUE' ? '진보 독자' : '보수 독자'}
       </div>
 
       {/* desktop only */}

--- a/src/app/(main)/(home)/components/hotArticleSection/hotArticleGroup/hotArticleGroup.css.ts
+++ b/src/app/(main)/(home)/components/hotArticleSection/hotArticleGroup/hotArticleGroup.css.ts
@@ -55,16 +55,16 @@ export const ideologyLabel = recipe({
   },
   variants: {
     ideology: {
-      progressive: {
+      VALUE: {
         color: color.brand.progressive,
       },
-      conservative: {
+      NORM: {
         color: color.brand.conservative,
       },
     },
   },
   defaultVariants: {
-    ideology: 'progressive',
+    ideology: 'VALUE',
   },
 });
 

--- a/src/app/(main)/(home)/components/hotIssueSection/hotIssueArticleItem/HotIssueArticleItem.tsx
+++ b/src/app/(main)/(home)/components/hotIssueSection/hotIssueArticleItem/HotIssueArticleItem.tsx
@@ -5,14 +5,14 @@ import { useRouter } from 'next/navigation';
 
 import { ROUTES } from '@/shared/constants/route';
 import IdeologyIndicator from '@/common/components/indicator/IdeologyIndicator';
-import { type IdeologyIndicatorValueTypes } from '@/common/components/indicator/constants';
+import { IdeologyFrameType } from '@/shared/types/frame';
 
 import * as styles from './hotIssueArticleItem.css';
 
 interface HotIssueArticleItemPropTypes {
   articleId: number;
   articleThumbnail: string;
-  frameType: IdeologyIndicatorValueTypes;
+  frameType: IdeologyFrameType;
   articleTitle: string;
   mediaName: string;
 }

--- a/src/app/(main)/(home)/components/hotIssueSection/hotIssueHeader/HotIssueHeader.tsx
+++ b/src/app/(main)/(home)/components/hotIssueSection/hotIssueHeader/HotIssueHeader.tsx
@@ -1,19 +1,21 @@
 import Image from 'next/image';
 
+import { FrameSide } from '@/shared/types/frame';
+
 import * as styles from './hotIssueHeader.css';
 
 interface HotIssueHeaderPropTypes {
-  ideology: 'progressive' | 'conservative';
+  ideology: FrameSide;
   keyword: string;
 }
 
-const IDEOLOGY_ICON_PATHS: Record<HotIssueHeaderPropTypes['ideology'], string> = {
-  progressive: '/icons/ic_hash_blue.svg',
-  conservative: '/icons/ic_hash_red.svg',
+const IDEOLOGY_ICON_PATHS: Record<FrameSide, string> = {
+  VALUE: '/icons/ic_hash_blue.svg',
+  NORM: '/icons/ic_hash_red.svg',
 };
 
 const HotIssueHeader = ({ ideology, keyword }: HotIssueHeaderPropTypes) => {
-  const iconPath = IDEOLOGY_ICON_PATHS[ideology] ?? IDEOLOGY_ICON_PATHS.conservative;
+  const iconPath = IDEOLOGY_ICON_PATHS[ideology];
 
   return (
     <div className={styles.container}>

--- a/src/app/(main)/(home)/constants/index.ts
+++ b/src/app/(main)/(home)/constants/index.ts
@@ -38,14 +38,14 @@ export const SCOPE_CATEGORY_TABS = [
 
 // 모바일 뷰 이념별로 뉴스 모아보기(BY IDEOLOGY) 섹션 카테고리
 export const BY_IDEOLOGY_CATEGORY_TABS = [
-  { key: 'progressive', label: '진보 성향' },
-  { key: 'center', label: '중도 성향' },
-  { key: 'conservative', label: '보수 성향' },
+  { key: 'VALUE', label: '진보 성향' },
+  { key: 'NEUTRAL', label: '중도 성향' },
+  { key: 'NORM', label: '보수 성향' },
 ];
 
 // 추후 scope 아티클 세부 페이지 구현 시, 해당 상수 파일 옮기기
 export const SUMMARY_CATEGORY_TABS = [
-  { key: 'progressive', label: '진보 성향 기사 요약 보기', mobileLabel: '진보 성향' },
-  { key: 'center', label: '중도 성향 기사 요약 보기', mobileLabel: '중도 성향' },
-  { key: 'conservative', label: '보수 성향 기사 요약 보기', mobileLabel: '보수 성향' },
+  { key: 'VALUE', label: '진보 성향 기사 요약 보기', mobileLabel: '진보 성향' },
+  { key: 'NEUTRAL', label: '중도 성향 기사 요약 보기', mobileLabel: '중도 성향' },
+  { key: 'NORM', label: '보수 성향 기사 요약 보기', mobileLabel: '보수 성향' },
 ] as const;

--- a/src/app/(main)/(home)/types/byIdeologySection.ts
+++ b/src/app/(main)/(home)/types/byIdeologySection.ts
@@ -1,4 +1,4 @@
-import { type ArticleBaseTypes } from '@/shared/types/articleItemType';
+import { type ArticleBaseTypes } from '@/shared/components/articlePreviewItem/types';
 
 export type IdeologyType = 'progressive' | 'center' | 'conservative';
 

--- a/src/app/(main)/(home)/types/byIdeologySection.ts
+++ b/src/app/(main)/(home)/types/byIdeologySection.ts
@@ -1,8 +1,7 @@
 import { type ArticleBaseTypes } from '@/shared/components/articlePreviewItem/types';
-
-export type IdeologyType = 'progressive' | 'center' | 'conservative';
+import { BaseFrameType } from '@/shared/types/frame';
 
 export interface ByIdeologySectionGroupTypes {
-  ideology: IdeologyType;
+  ideology: BaseFrameType;
   articleItems: ArticleBaseTypes[];
 }

--- a/src/app/(main)/(home)/types/hotArticleSection.ts
+++ b/src/app/(main)/(home)/types/hotArticleSection.ts
@@ -1,4 +1,4 @@
-import { type ArticleBaseTypes } from '@/shared/types/articleItemType';
+import { type ArticleBaseTypes } from '@/shared/components/articlePreviewItem/types';
 
 export type IdeologyType = 'progressive' | 'conservative';
 

--- a/src/app/(main)/(home)/types/hotArticleSection.ts
+++ b/src/app/(main)/(home)/types/hotArticleSection.ts
@@ -1,8 +1,8 @@
 import { type ArticleBaseTypes } from '@/shared/components/articlePreviewItem/types';
 
-export type IdeologyType = 'progressive' | 'conservative';
+import { FrameSide } from '@/shared/types/frame';
 
 export interface HotArticleSectionGroupTypes {
-  ideology: IdeologyType;
+  ideology: FrameSide;
   articleItems: ArticleBaseTypes[];
 }

--- a/src/app/(main)/(home)/types/hotIssueSection.ts
+++ b/src/app/(main)/(home)/types/hotIssueSection.ts
@@ -1,16 +1,16 @@
-import { type IdeologyIndicatorValueTypes } from '@/common/components/indicator/constants';
+import { FrameSide, IdeologyFrameType } from '@/shared/types/frame';
 
 export interface HotIssueArticleItemTypes {
   articleId: number;
   articleThumbnail: string;
-  frameType: IdeologyIndicatorValueTypes;
+  frameType: IdeologyFrameType;
   articleTitle: string;
   mediaName: string;
 }
 
 export interface HotIssueGroupTypes {
   keywordId: number;
-  ideology: 'progressive' | 'conservative';
+  ideology: FrameSide;
   keyword: string;
   articleItems: HotIssueArticleItemTypes[];
 }

--- a/src/app/(main)/article/link/[id]/components/linkDetailHeader/LinkDetailHeader.tsx
+++ b/src/app/(main)/article/link/[id]/components/linkDetailHeader/LinkDetailHeader.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import ArticleDetailActions from '@/app/(main)/article/components/articleDetailActions/ArticleDetailActions';
 import ShareModal from '@/app/(main)/article/components/shareModal/ShareModal';
 import IdeologyIndicator from '@/common/components/indicator/IdeologyIndicator';
-import { IdeologyIndicatorValueTypes } from '@/common/components/indicator/constants';
+import { IdeologyFrameType } from '@/shared/types/frame';
 
 import * as styles from './linkDetailHeader.css';
 
@@ -15,7 +15,7 @@ interface LinkDetailHeaderPropTypes {
   summary: string;
   newsAgencyName: string;
   publishedAt: string;
-  frameType: IdeologyIndicatorValueTypes;
+  frameType: IdeologyFrameType;
   isScraped: boolean;
 }
 

--- a/src/app/(main)/article/link/[id]/types/linkDetailSection.ts
+++ b/src/app/(main)/article/link/[id]/types/linkDetailSection.ts
@@ -1,11 +1,11 @@
-import type { IdeologyIndicatorValueTypes } from '@/common/components/indicator/constants';
+import { IdeologyFrameType } from '@/shared/types/frame';
 
 export interface LinkDetailTypes {
   id: number;
   title: string;
   newsAgencyName: string;
   publishedAt: string;
-  frameType: IdeologyIndicatorValueTypes;
+  frameType: IdeologyFrameType;
   summary: string;
   articleUrl: string;
   isScraped: boolean;

--- a/src/app/(main)/article/scope/[id]/components/articleSummarySection/ArticleSummarySection.tsx
+++ b/src/app/(main)/article/scope/[id]/components/articleSummarySection/ArticleSummarySection.tsx
@@ -15,7 +15,7 @@ interface ArticleSummarySectionPropTypes {
 }
 
 const ArticleSummarySection = ({ mainArticles }: ArticleSummarySectionPropTypes) => {
-  const [summaryActiveKey, setSummaryActiveKey] = useState<string>('progressive');
+  const [summaryActiveKey, setSummaryActiveKey] = useState<string>('VALUE');
   const summaryItem = mainArticles[summaryActiveKey as keyof ArticleSummarySectionTypes];
 
   return (

--- a/src/app/(main)/article/scope/[id]/types/articleSummarySection.ts
+++ b/src/app/(main)/article/scope/[id]/types/articleSummarySection.ts
@@ -1,7 +1,7 @@
-import { type IdeologyIndicatorValueTypes } from '@/common/components/indicator/constants';
+import { IdeologyFrameType } from '@/shared/types/frame';
 
 export interface ArticleSummaryItemTypes {
-  frameType: IdeologyIndicatorValueTypes;
+  frameType: IdeologyFrameType;
   id: number;
   newsAgencyName: string;
   publishedAt?: string;
@@ -10,7 +10,7 @@ export interface ArticleSummaryItemTypes {
 }
 
 export interface ArticleSummarySectionTypes {
-  center: ArticleSummaryItemTypes;
-  conservative: ArticleSummaryItemTypes;
-  progressive: ArticleSummaryItemTypes;
+  NEUTRAL: ArticleSummaryItemTypes;
+  NORM: ArticleSummaryItemTypes;
+  VALUE: ArticleSummaryItemTypes;
 }

--- a/src/app/(main)/article/scope/[id]/types/scopeDetailSection.ts
+++ b/src/app/(main)/article/scope/[id]/types/scopeDetailSection.ts
@@ -1,6 +1,5 @@
 import type { ArticleSummarySectionTypes } from '@/app/(main)/article/scope/[id]/types/articleSummarySection';
-
-export type DominantFrameType = 'VALUE' | 'NEUTRAL' | 'NORM' | 'BALANCED';
+import { ScopeFrameType } from '@/shared/types/frame';
 
 export interface ScopeDetailArticleCountTypes {
   neutral: number;
@@ -21,6 +20,6 @@ export interface ScopeDetailTypes {
   keywordSummary: string;
   articleCount: ScopeDetailArticleCountTypes;
   bias: number;
-  dominantFrameType: DominantFrameType;
+  dominantFrameType: ScopeFrameType;
   mainArticles: ArticleSummarySectionTypes;
 }

--- a/src/app/(main)/article/types/relatedArticleSection.ts
+++ b/src/app/(main)/article/types/relatedArticleSection.ts
@@ -1,7 +1,7 @@
 import {
   type ArticleBaseTypes,
   type ExpandedArticleExtraTypes,
-} from '@/shared/types/articleItemType';
+} from '@/shared/components/articlePreviewItem/types';
 
 export type IdeologyType = 'progressive' | 'center' | 'conservative';
 

--- a/src/app/(main)/article/types/relatedArticleSection.ts
+++ b/src/app/(main)/article/types/relatedArticleSection.ts
@@ -3,9 +3,9 @@ import {
   type ExpandedArticleExtraTypes,
 } from '@/shared/components/articlePreviewItem/types';
 
-export type IdeologyType = 'progressive' | 'center' | 'conservative';
+import { BaseFrameType } from '@/shared/types/frame';
 
 export interface RelatedArticleSectionGroupTypes {
-  ideology: IdeologyType;
+  ideology: BaseFrameType;
   articleItems: (ArticleBaseTypes & ExpandedArticleExtraTypes)[];
 }

--- a/src/app/(main)/search/components/searchResultContent/newsResultList/NewsResultList.tsx
+++ b/src/app/(main)/search/components/searchResultContent/newsResultList/NewsResultList.tsx
@@ -3,7 +3,7 @@
 import * as styles from './newsResultList.css';
 
 import ArticlePreviewItem from '@/shared/components/articlePreviewItem/ArticlePreviewItem';
-import type { SearchArticlePreviewItemTypes } from '@/shared/types/articleItemType';
+import type { SearchArticlePreviewItemTypes } from '@/shared/components/articlePreviewItem/types';
 
 interface NewsListPropTypes {
   items: SearchArticlePreviewItemTypes[];

--- a/src/app/(main)/search/page.tsx
+++ b/src/app/(main)/search/page.tsx
@@ -7,7 +7,7 @@ import NewsResultList from './components/searchResultContent/newsResultList/News
 import ScopeResultList from './components/searchResultContent/scopeResultList/ScopeResultList';
 import { useState } from 'react';
 import { SEARCH_TAB_LIST, SearchTabValue } from '@/shared/components/articleTabs/constants';
-import type { SearchArticlePreviewItemTypes } from '@/shared/types/articleItemType';
+import type { SearchArticlePreviewItemTypes } from '@/shared/components/articlePreviewItem/types';
 import { NewsArticleItemData } from './types/search';
 import { SEARCH_RESULT_DATA } from '@/mocks/data/search';
 import SearchPagenation from './components/searchPagenation/SearchPagenation';

--- a/src/app/(main)/search/types/search.ts
+++ b/src/app/(main)/search/types/search.ts
@@ -1,4 +1,4 @@
-import { SearchArticlePreviewItemTypes } from '@/shared/types/articleItemType';
+import { SearchArticlePreviewItemTypes } from '@/shared/components/articlePreviewItem/types';
 
 // search 결과 list 중 NewsResultList에 해당하는 타입
 export type NewsArticleItemData = {

--- a/src/common/components/filterTabs/FilterTabs.tsx
+++ b/src/common/components/filterTabs/FilterTabs.tsx
@@ -22,9 +22,9 @@ const FilterTabs = ({ tabs, activeKey, onChange, variant = 'scope' }: FilterTabs
               tab.key === activeKey
                 ? styles.activeTab({
                     tone: (variant === 'byIdeology' ? tab.key : 'default') as
-                      | 'progressive'
-                      | 'center'
-                      | 'conservative'
+                      | 'VALUE'
+                      | 'NEUTRAL'
+                      | 'NORM'
                       | 'default',
                   })
                 : ''

--- a/src/common/components/filterTabs/filterTabs.css.ts
+++ b/src/common/components/filterTabs/filterTabs.css.ts
@@ -112,15 +112,15 @@ export const activeTab = recipe({
         color: color.text.main,
       },
 
-      progressive: {
+      VALUE: {
         color: color.brand.progressive,
       },
 
-      center: {
+      NEUTRAL: {
         color: color.brand.center,
       },
 
-      conservative: {
+      NORM: {
         color: color.brand.conservative,
       },
     },

--- a/src/common/components/indicator/constants.ts
+++ b/src/common/components/indicator/constants.ts
@@ -1,20 +1,22 @@
 import { color, typography } from '@/shared/styles';
+import { IdeologyFrameType } from '@/shared/types/frame';
 
 /**
  * 이념 지표 관련 데이터 상수화
  */
 
 // 이념 지표 옵션 리스트 (value, label)
-export const IDEOLOGY_OPTIONS = [
+export const IDEOLOGY_OPTIONS: {
+  value: IdeologyFrameType;
+
+  label: string;
+}[] = [
   { value: 'STRONG_VALUE', label: 'SL' },
   { value: 'VALUE', label: 'L' },
   { value: 'NEUTRAL', label: 'C' },
   { value: 'NORM', label: 'R' },
   { value: 'STRONG_NORM', label: 'SR' },
-] as const;
-
-// 이념 지표 값 타입
-export type IdeologyIndicatorValueTypes = (typeof IDEOLOGY_OPTIONS)[number]['value'];
+];
 
 //------------------------------------------------
 

--- a/src/mocks/data/home.ts
+++ b/src/mocks/data/home.ts
@@ -8,7 +8,7 @@ import { type RelatedArticleSectionGroupTypes } from '@/app/(main)/article/types
 export const HOT_ISSUE_ARTICLE_GROUP: HotIssueGroupTypes[] = [
   {
     keywordId: 1,
-    ideology: 'progressive',
+    ideology: 'VALUE',
     keyword: '키워드',
     articleItems: [
       {
@@ -31,7 +31,7 @@ export const HOT_ISSUE_ARTICLE_GROUP: HotIssueGroupTypes[] = [
   },
   {
     keywordId: 2,
-    ideology: 'conservative',
+    ideology: 'NORM',
     keyword: '키워드',
     articleItems: [
       {
@@ -54,7 +54,7 @@ export const HOT_ISSUE_ARTICLE_GROUP: HotIssueGroupTypes[] = [
   },
   {
     keywordId: 3,
-    ideology: 'progressive',
+    ideology: 'VALUE',
     keyword: '키워드',
     articleItems: [
       {
@@ -77,7 +77,7 @@ export const HOT_ISSUE_ARTICLE_GROUP: HotIssueGroupTypes[] = [
   },
   {
     keywordId: 4,
-    ideology: 'conservative',
+    ideology: 'NORM',
     keyword: '키워드',
     articleItems: [
       {
@@ -100,7 +100,7 @@ export const HOT_ISSUE_ARTICLE_GROUP: HotIssueGroupTypes[] = [
   },
   {
     keywordId: 5,
-    ideology: 'progressive',
+    ideology: 'VALUE',
     keyword: '키워드',
     articleItems: [
       {
@@ -123,7 +123,7 @@ export const HOT_ISSUE_ARTICLE_GROUP: HotIssueGroupTypes[] = [
   },
   {
     keywordId: 6,
-    ideology: 'conservative',
+    ideology: 'NORM',
     keyword: '키워드',
     articleItems: [
       {
@@ -532,7 +532,7 @@ export const MOCK_SCOPE_ARTICLES: Record<string, ScopeArticleItemData[]> = {
  */
 export const HOT_ARTICLE_GROUP: HotArticleSectionGroupTypes[] = [
   {
-    ideology: 'progressive',
+    ideology: 'VALUE',
     articleItems: [
       {
         articleId: 1,
@@ -579,7 +579,7 @@ export const HOT_ARTICLE_GROUP: HotArticleSectionGroupTypes[] = [
     ],
   },
   {
-    ideology: 'conservative',
+    ideology: 'NORM',
     articleItems: [
       {
         articleId: 7,
@@ -629,7 +629,7 @@ export const HOT_ARTICLE_GROUP: HotArticleSectionGroupTypes[] = [
 
 export const BY_IDEOLOGY_SECTION_DATA: ByIdeologySectionGroupTypes[] = [
   {
-    ideology: 'progressive',
+    ideology: 'VALUE',
     articleItems: [
       {
         articleId: 1,
@@ -704,7 +704,7 @@ export const BY_IDEOLOGY_SECTION_DATA: ByIdeologySectionGroupTypes[] = [
     ],
   },
   {
-    ideology: 'center',
+    ideology: 'NEUTRAL',
     articleItems: [
       {
         articleId: 11,
@@ -779,7 +779,7 @@ export const BY_IDEOLOGY_SECTION_DATA: ByIdeologySectionGroupTypes[] = [
     ],
   },
   {
-    ideology: 'conservative',
+    ideology: 'NORM',
     articleItems: [
       {
         articleId: 21,
@@ -858,7 +858,7 @@ export const BY_IDEOLOGY_SECTION_DATA: ByIdeologySectionGroupTypes[] = [
 // 스코프, 링크 세부 페이지 연관기사 영역 데이터
 export const RELATED_ARTICLE_SECTION_DATA: RelatedArticleSectionGroupTypes[] = [
   {
-    ideology: 'progressive',
+    ideology: 'VALUE',
     articleItems: [
       {
         articleId: 1,
@@ -883,7 +883,7 @@ export const RELATED_ARTICLE_SECTION_DATA: RelatedArticleSectionGroupTypes[] = [
     ],
   },
   {
-    ideology: 'center',
+    ideology: 'NEUTRAL',
     articleItems: [
       {
         articleId: 3,
@@ -908,7 +908,7 @@ export const RELATED_ARTICLE_SECTION_DATA: RelatedArticleSectionGroupTypes[] = [
     ],
   },
   {
-    ideology: 'conservative',
+    ideology: 'NORM',
     articleItems: [
       {
         articleId: 5,

--- a/src/mocks/data/scopeDetail.ts
+++ b/src/mocks/data/scopeDetail.ts
@@ -20,7 +20,7 @@ export const SCOPE_DETAIL_MOCK = {
   bias: 44,
   dominantFrameType: 'VALUE',
   mainArticles: {
-    center: {
+    NEUTRAL: {
       frameType: 'NEUTRAL',
       id: 15,
       newsAgencyName: '경향신문',
@@ -28,7 +28,7 @@ export const SCOPE_DETAIL_MOCK = {
       summary: '요약요약dddd',
       title: '기사 제목',
     },
-    conservative: {
+    NORM: {
       frameType: 'NORM',
       id: 113,
       newsAgencyName: '경향신문',
@@ -36,7 +36,7 @@ export const SCOPE_DETAIL_MOCK = {
       summary: '요약요약',
       title: '기사 제목',
     },
-    progressive: {
+    VALUE: {
       frameType: 'STRONG_VALUE',
       id: 5,
       newsAgencyName: '경향신문',

--- a/src/shared/components/articlePreviewItem/ArticlePreviewItem.tsx
+++ b/src/shared/components/articlePreviewItem/ArticlePreviewItem.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { ROUTES } from '@/shared/constants/route';
 import IdeologyIndicator from '@/common/components/indicator/IdeologyIndicator';
 import { type IdeologyIndicatorResponsiveSizeTypes } from '@/common/components/indicator/types';
-import { type ArticlePreviewItemTypes } from '@/shared/types/articleItemType';
+import { type ArticlePreviewItemTypes } from '@/shared/components/articlePreviewItem/types';
 
 import * as styles from './articlePreviewItem.css';
 

--- a/src/shared/components/articlePreviewItem/types.ts
+++ b/src/shared/components/articlePreviewItem/types.ts
@@ -1,12 +1,12 @@
 // articleItemType.ts
-import { type IdeologyIndicatorValueTypes } from '@/common/components/indicator/constants';
+import { IdeologyFrameType } from '../../types/frame';
 
 // 아티클 아이템 기본 공통 타입 (default, compact, expanded, search 모두 사용)
 export interface ArticleBaseTypes {
   articleId: number;
   mediaName: string;
   articleTitle: string;
-  frameType: IdeologyIndicatorValueTypes;
+  frameType: IdeologyFrameType;
   //   onArticleClick: (articleId: number) => void;
 }
 

--- a/src/shared/components/articleTabs/constants.ts
+++ b/src/shared/components/articleTabs/constants.ts
@@ -1,10 +1,12 @@
+import type { BaseFrameType } from '@/shared/types/frame';
+
 // 연관 기사 필터링 탭 상수
 export const RELATED_ARTICLE_TAB_LIST = [
   { label: '전체', value: 'all' },
-  { label: '진보', value: 'progressive' },
-  { label: '중도', value: 'center' },
-  { label: '보수', value: 'conservative' },
-] as const;
+  { label: '진보', value: 'VALUE' },
+  { label: '중도', value: 'NEUTRAL' },
+  { label: '보수', value: 'NORM' },
+] as const satisfies readonly ArticleTabItem<RelatedArticleTabValue>[];
 
 // 검색 결과 필터링 탭 상수
 export const SEARCH_TAB_LIST = [
@@ -12,7 +14,7 @@ export const SEARCH_TAB_LIST = [
   { label: 'NEWS', value: 'news' },
 ] as const;
 
-export type RelatedArticleTabValue = (typeof RELATED_ARTICLE_TAB_LIST)[number]['value'];
+export type RelatedArticleTabValue = 'all' | BaseFrameType;
 export type SearchTabValue = (typeof SEARCH_TAB_LIST)[number]['value'];
 export type ArticleTabValue = RelatedArticleTabValue | SearchTabValue;
 

--- a/src/shared/types/frame.ts
+++ b/src/shared/types/frame.ts
@@ -1,0 +1,10 @@
+export type BaseFrameType = 'VALUE' | 'NEUTRAL' | 'NORM';
+
+export type IdeologyFrameType = BaseFrameType | 'STRONG_VALUE' | 'STRONG_NORM';
+
+export type ScopeFrameType = BaseFrameType | 'BALANCED';
+
+// VALUE | NORM
+export type FrameSide = Exclude<BaseFrameType, 'NEUTRAL'>;
+
+export type FrameFilterType = 'all' | BaseFrameType;


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #170 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- frame 관련 공통 타입을 추가했습니다.
- 프로젝트 전반에서 사용하던 이념 관련 타입 값을 VALUE, NEUTRAL, NORM 기준으로 통일했습니다.
- ArticlePreviewItem 타입 파일을 컴포넌트 폴더 내부로 이동하고 types.ts로 네이밍을 정리했습니다.


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
- 기존 progressive, center, conservative 값을 사용하던 영역을 공통 frame 타입 기준으로 변경했습니다.
- 타입 중앙화 과정에서 관련 컴포넌트 및 목데이터의 타입 참조 경로가 함께 수정되었습니다.

### frame.ts (shared/types/)
- 프로젝트 전반에서 사용하는 frame 관련 공통 타입을 정의했습니다.
- 이념 분류(`VALUE`, `NEUTRAL`, `NORM`), 기사 프레임, Scope 프레임, 필터 타입을 중앙화했습니다.
- 기존에 사용하던 `progressive`, `center`, `conservative` 값을 frame 타입 기준으로 통일할 수 있도록 공통 타입을 제공합니다.
```ts
/**
 * 기사 성향 분류 타입
 */
export type BaseFrameType = 'VALUE' | 'NEUTRAL' | 'NORM';

/**
 * 기사 프레임 타입
 * 강한 성향(STRONG)을 포함한 기사 프레임 분류
 */
export type IdeologyFrameType = BaseFrameType | 'STRONG_VALUE' | 'STRONG_NORM';

/**
 * Scope 대표 프레임 타입
 * BALANCED(균형) 상태를 포함
 */
export type ScopeFrameType = BaseFrameType | 'BALANCED';

/**
 * 가치/규범 양극 성향 타입
 */
export type FrameSide = Exclude<BaseFrameType, 'NEUTRAL'>;

/**
 * 프레임 필터 타입
 * 전체 조회를 위한 all 포함
 */
export type FrameFilterType = 'all' | BaseFrameType;
```

## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->


## 📚 Reference
<!-- 참고한 아티클 링크 / 새롭게 알게 된 점이 있다면 적어주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 이념/프레임 표기 체계를 통합해, 진보·중도·보수 데이터와 표시(색상/레이블)가 전반적으로 일관되게 맞춰졌습니다.
  * 필터 탭과 섹션 헤더의 톤/테마 매핑이 최신 체계에 맞게 정리되었습니다.

* **Bug Fixes**
  * 일부 화면의 초기 선택 탭(요약 섹션, 이데올로기 섹션)과 이념 레이블 조건이 수정되어 표시가 안정적으로 동작합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->