### PR TITLE
[Refactor] ideology 공통 타입 Scope 관련 적용

### DIFF
--- a/src/app/(main)/(home)/components/scopeCarousel/ScopeCarousel.tsx
+++ b/src/app/(main)/(home)/components/scopeCarousel/ScopeCarousel.tsx
@@ -54,12 +54,12 @@ const ScopeCarousel = () => {
               <ScopeCarouselItem
                 title={category.valueArticleTitle}
                 imageUrl={category.valueImageUrl}
-                ideology="value"
+                ideology="VALUE"
               />
               <ScopeCarouselItem
                 title={category.normArticleTitle}
                 imageUrl={category.normImageUrl}
-                ideology="norm"
+                ideology="NORM"
               />
             </div>
           ))}

--- a/src/app/(main)/(home)/components/scopeCarousel/scopeCarouselItem/ScopeCarouselItem.tsx
+++ b/src/app/(main)/(home)/components/scopeCarousel/scopeCarouselItem/ScopeCarouselItem.tsx
@@ -1,15 +1,15 @@
 import Image from 'next/image';
 import * as styles from './scopeCarouselItem.css';
-import { IdeologyType } from '@/shared/components/scopeArticleItem/types';
+import { ScopeFrameType } from '@/shared/types/frame';
 
 interface ScopeCarouselItemPropTypes {
   title: string;
   imageUrl: string;
-  ideology: IdeologyType;
+  ideology: ScopeFrameType;
 }
 
 const ScopeCarouselItem = ({ title, imageUrl, ideology }: ScopeCarouselItemPropTypes) => {
-  const isValue = ideology === 'value';
+  const isValue = ideology === 'VALUE';
   const barClass = isValue ? styles.valueBar : styles.normBar;
 
   return (

--- a/src/app/(main)/article/components/reportSummarySection/ReportSummarySection.tsx
+++ b/src/app/(main)/article/components/reportSummarySection/ReportSummarySection.tsx
@@ -2,7 +2,7 @@
 
 import { Fragment } from 'react';
 import { useMediaQuery } from '@/shared/hooks/useMediaQuery';
-import type { IdeologyType } from '@/shared/components/scopeArticleItem/types';
+import type { ScopeFrameType } from '@/shared/types/frame';
 import * as styles from './reportSummarySection.css';
 import { IDEOLOGY_LABELS, ITEM_LABELS } from './constants';
 
@@ -21,7 +21,7 @@ interface ReportSummarySectionPropTypes {
     valueRatio: number;
   };
   bias: number;
-  dominantFrameType: string;
+  dominantFrameType: ScopeFrameType;
 }
 
 const ReportSummarySection = ({
@@ -40,14 +40,6 @@ const ReportSummarySection = ({
   const neutralCount = articleCount.neutral;
   const totalNewsCount = articleCount.value + articleCount.norm + articleCount.neutral;
   const biasPercentage = bias;
-
-  // dominantFrameType을 IdeologyType으로 변환 (추후 통일)
-  const biasIdeologyMap: Record<string, IdeologyType> = {
-    VALUE: 'value',
-    NORM: 'norm',
-    NEUTRAL: 'neutral',
-  };
-  const biasIdeology: IdeologyType = biasIdeologyMap[dominantFrameType] || 'center';
 
   // 숫자 값에 '건' 단위를 붙여 반환 — mobile 전용
   const countValue = (count: number) =>
@@ -78,10 +70,10 @@ const ReportSummarySection = ({
       value: isMobile ? (
         <>
           {biasPercentage}
-          <span className={styles.unit}>%</span> {IDEOLOGY_LABELS[biasIdeology]}
+          <span className={styles.unit}>%</span> {IDEOLOGY_LABELS[dominantFrameType]}
         </>
       ) : (
-        `${biasPercentage}% ${IDEOLOGY_LABELS[biasIdeology]}`
+        `${biasPercentage}% ${IDEOLOGY_LABELS[dominantFrameType]}`
       ),
     },
   ];

--- a/src/app/(main)/article/components/reportSummarySection/constants.ts
+++ b/src/app/(main)/article/components/reportSummarySection/constants.ts
@@ -1,10 +1,11 @@
-import type { IdeologyType } from '@/shared/components/scopeArticleItem/types';
+import { ScopeFrameType } from '@/shared/types/frame';
 
 // 중앙화 필요
-export const IDEOLOGY_LABELS: Record<IdeologyType, string> = {
-  value: '진보',
-  neutral: '중도',
-  norm: '보수',
+export const IDEOLOGY_LABELS: Record<ScopeFrameType, string> = {
+  VALUE: '진보',
+  NEUTRAL: '중도',
+  NORM: '보수',
+  BALANCED: '균형',
 };
 
 // 브레이크포인트별 레이블 상수

--- a/src/mocks/data/home.ts
+++ b/src/mocks/data/home.ts
@@ -240,7 +240,7 @@ export const SCOPE_CAROUSEL_DATA: ScopeCarouselDataType[] = [
       value: 5,
       valueRatio: 0.33,
     },
-    id: 21,
+    id: 27,
     name: '삼성전자',
     normArticleTitle: '보수 기사 제목입니다 ~',
     normImageUrl: 'https://i.pinimg.com/736x/44/b0/f0/44b0f0315ece65cdc3b64130c91ea009.jpg',

--- a/src/shared/components/scopeArticleItem/ScopeArticleItem.tsx
+++ b/src/shared/components/scopeArticleItem/ScopeArticleItem.tsx
@@ -6,11 +6,7 @@ import { useRouter } from 'next/navigation';
 import ScopePercentBar from '@/common/components/percentBar/ScopePercentBar';
 import { ROUTES } from '@/shared/constants/route';
 import { useMediaQuery } from '@/shared/hooks/useMediaQuery';
-import type {
-  IdeologyType,
-  ScopeArticleItemData,
-  ScopeDominantFrameType,
-} from '@/shared/components/scopeArticleItem/types';
+import type { ScopeArticleItemData } from '@/shared/components/scopeArticleItem/types';
 
 import { IDEOLOGY_LABELS, PERCENT_BAR_SIZE_BY_ITEM_SIZE } from './constants';
 import * as styles from './scopeArticleItem.css';
@@ -18,14 +14,6 @@ import * as styles from './scopeArticleItem.css';
 interface ScopeArticleItemPropTypes extends ScopeArticleItemData {
   size?: 'small' | 'large';
 }
-
-// NEUTRAL 타입과 BALANCED 타입을 구분해야하는지 확인 필요
-const FRAME_TYPE_TO_IDEOLOGY: Record<ScopeDominantFrameType, IdeologyType> = {
-  VALUE: 'value',
-  NEUTRAL: 'neutral',
-  BALANCED: 'neutral',
-  NORM: 'norm',
-};
 
 const ScopeArticleItem = ({
   articleCount,
@@ -38,15 +26,17 @@ const ScopeArticleItem = ({
   const router = useRouter();
   const percentBarSize = PERCENT_BAR_SIZE_BY_ITEM_SIZE[size];
   const breakpoint = useMediaQuery();
-  const ideology = FRAME_TYPE_TO_IDEOLOGY[dominantFrameType];
   const { valueRatio, neutralRatio, normRatio } = articleCount;
 
   const usesFramingDescription =
     breakpoint === 'desktop' || (breakpoint === 'tablet' && size === 'large');
 
-  const description = usesFramingDescription
-    ? `에 대해 ${IDEOLOGY_LABELS[ideology]} 성향으로 프레이밍한 기사가 더 많습니다.`
-    : `에 대해 ${IDEOLOGY_LABELS[ideology]} 관점으로 보도된 기사가 더 많습니다.`;
+  const description =
+    dominantFrameType === 'BALANCED'
+      ? '에 대한 기사가 다양한 관점에서 균형 있게 보도되었습니다.'
+      : usesFramingDescription
+        ? `에 대해 ${IDEOLOGY_LABELS[dominantFrameType]} 성향으로 프레이밍한 기사가 더 많습니다.`
+        : `에 대해 ${IDEOLOGY_LABELS[dominantFrameType]} 관점으로 보도된 기사가 더 많습니다.`;
 
   return (
     <div

--- a/src/shared/components/scopeArticleItem/constants.ts
+++ b/src/shared/components/scopeArticleItem/constants.ts
@@ -1,13 +1,13 @@
-import type { IdeologyType } from './types';
+import { BaseFrameType } from '@/shared/types/frame';
 
 /**
  * ScopeArticleItem 컴포넌트의 상수
  */
 
-export const IDEOLOGY_LABELS: Record<IdeologyType, string> = {
-  value: '진보',
-  neutral: '중도',
-  norm: '보수',
+export const IDEOLOGY_LABELS: Record<BaseFrameType, string> = {
+  VALUE: '진보',
+  NEUTRAL: '중도',
+  NORM: '보수',
 } as const;
 
 /**

--- a/src/shared/components/scopeArticleItem/types.ts
+++ b/src/shared/components/scopeArticleItem/types.ts
@@ -1,9 +1,4 @@
-/**
- * Ideology 타입
- */
-export type IdeologyType = 'value' | 'neutral' | 'norm';
-
-export type ScopeDominantFrameType = 'VALUE' | 'NEUTRAL' | 'NORM' | 'BALANCED';
+import { ScopeFrameType } from '@/shared/types/frame';
 
 /**
  * ScopeArticleItem 컴포넌트에 전달되는 기사 아이템 데이터
@@ -22,7 +17,7 @@ export interface ScopeArticleItemData {
     value: number;
     valueRatio: number;
   };
-  dominantFrameType: ScopeDominantFrameType;
+  dominantFrameType: ScopeFrameType;
   id: number;
   imageUrl: string;
   name: string;


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #180 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- 스코프 관련 컴포넌트에서 개별적으로 선언해 사용하던 이념 타입을 공용 `ScopeFrameType`, `BaseFrameType`으로 통합했습니다.
- 이념 값을 소문자(`value`, `neutral`, `norm`)에서 API 응답 형식인 대문자(`VALUE`, `NEUTRAL`, `NORM`)로 통일했습니다.
- `ScopeArticleItem`의 불필요한 프레임 타입 변환 로직을 제거하고 `dominantFrameType`을 직접 사용하도록 변경했습니다.
- `BALANCED` 타입일 때 균형 보도에 맞는 별도 설명 문구가 표시되도록 처리했습니다. (`에 대한 기사가 다양한 관점에서 균형 있게 보도되었습니다.`)
- `ReportSummarySection`의 `dominantFrameType`을 `ScopeFrameType`으로 지정해 라벨 객체 인덱싱 타입 오류를 해결했습니다.
- `ReportSummarySection` 이념 라벨에 `BALANCED: '균형'`을 추가했습니다.
- `ScopeCarouselItem`과 `ScopeCarousel`에서 공용 프레임 타입 및 대문자 이념 값을 사용하도록 변경했습니다.
- 홈 스코프 캐러셀 목 데이터의 잘못된 ID를 `21`에서 `27`로 수정했습니다.


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
- 기존 `IdeologyType`, `ScopeDominantFrameType`은 공용 타입과 역할이 중복되어 제거했습니다.
- `ReportSummarySection`에서 frame type이 `BALANCED`일 때, '균형'으로 라벨링했는데, 이에 관한 기획/디자인 측의 확인이 필요합니다.
- ScopeCarousel에 '중도' 기사가 들어가는 경우를 고려하여 수정하려고 했으나, 현재 백엔드 api 응답구조를 확인했을 때 무조건 value / norm 두가지의 기사를 전달하고 있으므로 추후 회의에서 이에 관한 백엔드 측과의 논의가 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 프레임 타입 분류 체계를 표준화하여 일관된 데이터 표시 확보

* **개선 사항**
  * 균형잡힌 관점(BALANCED) 프레임 타입 라벨 지원 추가
  * 이념 및 관점 표시 로직 정확성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->