### PR TITLE
[Feat] StepHeader 컴포넌트 구현

### DIFF
--- a/src/app/(main)/balenz-test/profile/components/stepheader/Stepheader.tsx
+++ b/src/app/(main)/balenz-test/profile/components/stepheader/Stepheader.tsx
@@ -1,0 +1,17 @@
+import * as styles from './stepheader.css';
+
+interface StepHeaderProps {
+  section: string;
+  title: string;
+}
+
+const StepHeader = ({ section, title }: StepHeaderProps) => {
+  return (
+    <header className={styles.container}>
+      <p className={styles.section}>{section}</p>
+      <h1 className={styles.title}>{title}</h1>
+    </header>
+  );
+};
+
+export default StepHeader;

--- a/src/app/(main)/balenz-test/profile/components/stepheader/constants.ts
+++ b/src/app/(main)/balenz-test/profile/components/stepheader/constants.ts
@@ -1,0 +1,10 @@
+export const STEP_HEADER = {
+  BIRTH_YEAR: {
+    section: '응답자 정보',
+    title: '태어난 연도를 선택해 주세요.',
+  },
+  LEGAL_GENDER: {
+    section: '응답자 정보',
+    title: '법적 성별을 선택해 주세요.',
+  },
+} as const;

--- a/src/app/(main)/balenz-test/profile/components/stepheader/stepheader.css.ts
+++ b/src/app/(main)/balenz-test/profile/components/stepheader/stepheader.css.ts
@@ -1,0 +1,32 @@
+import { style } from '@vanilla-extract/css';
+import { color, typography, media } from '@/shared/styles';
+
+export const container = style({
+  textAlign: 'center',
+});
+export const section = style({
+  ...typography.desktop.h3,
+  color: color.text.tertiary,
+  marginBottom: '0.3125rem',
+  '@media': {
+    [media.tablet]: {
+      ...typography.tablet.h3,
+    },
+    [media.mobile]: {
+      ...typography.phone.h3,
+    },
+  },
+});
+export const title = style({
+  ...typography.desktop.display,
+  color: color.text.main,
+  wordBreak: 'keep-all',
+  '@media': {
+    [media.tablet]: {
+      ...typography.tablet.display,
+    },
+    [media.mobile]: {
+      ...typography.phone.display,
+    },
+  },
+});


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #192 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- 정치 성향 테스트 단계에서 공통으로 사용하는 `StepHeader` 컴포넌트를 구현했습니다.
- 상단 섹션 문구와 단계별 타이틀을 props로 전달받아 렌더링하도록 구성했습니다.
- 데스크톱, 태블릿, 모바일 환경에 맞는 반응형 타이포그래피를 적용했습니다.
- 단계별 헤더 문구를 관리하는 상수 파일을 추가했습니다.


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
- 단계별 문구는 `constants.ts`에서 관리하며, 필요한 화면에서 해당 상수를 불러와 사용하도록 구성했습니다.

### 사용방법
```ts
import StepHeader from './components/stepheader/Stepheader';
import { STEP_HEADER } from './components/stepheader/constants';

export default function page() {
  return (
    <div>
      {/* 태어난 연도 */}
      <StepHeader section={STEP_HEADER.BIRTH_YEAR.section} title={STEP_HEADER.BIRTH_YEAR.title} />

      {/* 법적 성별 */}
      <StepHeader section={STEP_HEADER.LEGAL_GENDER.section} title={STEP_HEADER.LEGAL_GENDER.title} />
    </div>
  );
}

```


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| 태어난 연도 | 법적 성별 |
|--|--|
| <img width="440" height="99" alt="스크린샷 2026-07-16 오후 11 05 43" src="https://github.com/user-attachments/assets/1a32a85e-83c6-489f-aa70-0b24439544f7" /> | <img width="410" height="92" alt="스크린샷 2026-07-16 오후 11 06 00" src="https://github.com/user-attachments/assets/2683b415-2d70-41d3-9780-2b5b0f4a4e4c" /> |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 프로필 단계별 안내 헤더를 추가했습니다.
  * 응답자 정보, 출생연도, 법적 성별 등 단계별 안내 문구를 표시합니다.
  * 화면 크기에 맞춰 헤더의 글꼴과 스타일이 조정됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->