### PR TITLE
[Feat] LikertOption 컴포넌트 구현

### DIFF
--- a/src/app/(main)/balenz-test/questions/components/likertOption/LikertOption.tsx
+++ b/src/app/(main)/balenz-test/questions/components/likertOption/LikertOption.tsx
@@ -1,0 +1,36 @@
+import type { LikertOptionData, LikertValue } from '../../types/likert';
+
+import * as styles from './likertOption.css';
+
+interface LikertOptionPropTypes {
+  name: string;
+  option: LikertOptionData;
+  checked: boolean;
+  onChange: (value: LikertValue) => void;
+}
+
+const LikertOption = ({ name, option, checked, onChange }: LikertOptionPropTypes) => {
+  const inputId = `${name}-${option.value}`;
+
+  return (
+    <label htmlFor={inputId} className={styles.option}>
+      <input
+        id={inputId}
+        className={styles.input}
+        type="radio"
+        name={name}
+        value={option.value}
+        checked={checked}
+        onChange={() => onChange(option.value)}
+      />
+
+      <span className={styles.circleWrapper}>
+        <span className={styles.circle({ size: option.size, selected: checked })} />
+      </span>
+
+      <span className={styles.label}>{option.label ?? ''}</span>
+    </label>
+  );
+};
+
+export default LikertOption;

--- a/src/app/(main)/balenz-test/questions/components/likertOption/constants.ts
+++ b/src/app/(main)/balenz-test/questions/components/likertOption/constants.ts
@@ -1,0 +1,38 @@
+/**
+ * LikertOption 컴포넌트 스타일 관련 상수
+ */
+
+// 전체 원 크기
+export const LIKERT_CIRCLE_SIZE = {
+  large: {
+    desktop: '6.25rem',
+    tablet: '3.90625rem',
+    mobile: '2.73438rem',
+  },
+  default: {
+    desktop: '4.6875rem',
+    tablet: '2.92969rem',
+    mobile: '2.05081rem',
+  },
+} as const;
+
+// 중심 작은 원 크기
+export const LIKERT_CENTER_CIRCLE_SIZE = {
+  desktop: '1.177rem',
+  tablet: '0.73563rem',
+  mobile: '0.51494rem',
+} as const;
+
+// 중심 원의 box shadow 크기 및 색상
+export const LIKERT_BOX_SHADOW = {
+  selected: {
+    desktop: '0 0 0 0.70625rem #767A7F',
+    tablet: '0 0 0 0.4412rem #767A7F',
+    mobile: '0 0 0 0.3088rem #767A7F',
+  },
+  unselected: {
+    desktop: '0 0 0 0.70625rem #F5F5F5',
+    tablet: '0 0 0 0.4412rem #F5F5F5',
+    mobile: '0 0 0 0.3088rem #F5F5F5',
+  },
+} as const;

--- a/src/app/(main)/balenz-test/questions/components/likertOption/likertOption.css.ts
+++ b/src/app/(main)/balenz-test/questions/components/likertOption/likertOption.css.ts
@@ -163,6 +163,8 @@ export const label = style({
   display: 'block',
   minHeight: '1.5em',
   color: color.text.tertiary,
+  textAlign: 'center',
+  wordBreak: 'keep-all',
   ...typography.desktop.body2,
 
   '@media': {

--- a/src/app/(main)/balenz-test/questions/components/likertOption/likertOption.css.ts
+++ b/src/app/(main)/balenz-test/questions/components/likertOption/likertOption.css.ts
@@ -42,7 +42,15 @@ export const circleWrapper = style({
 });
 
 export const input = style({
-  display: 'none',
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
 });
 
 export const circle = recipe({

--- a/src/app/(main)/balenz-test/questions/components/likertOption/likertOption.css.ts
+++ b/src/app/(main)/balenz-test/questions/components/likertOption/likertOption.css.ts
@@ -1,6 +1,7 @@
 import { color, media, typography } from '@/shared/styles';
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
+import { LIKERT_BOX_SHADOW, LIKERT_CENTER_CIRCLE_SIZE, LIKERT_CIRCLE_SIZE } from './constants';
 
 export const option = style({
   display: 'flex',
@@ -25,17 +26,17 @@ export const circleWrapper = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  width: '6.25rem',
-  height: '6.25rem',
+  width: LIKERT_CIRCLE_SIZE.large.desktop,
+  height: LIKERT_CIRCLE_SIZE.large.desktop,
 
   '@media': {
     [media.tablet]: {
-      width: '3.90625rem',
-      height: '3.90625rem',
+      width: LIKERT_CIRCLE_SIZE.large.tablet,
+      height: LIKERT_CIRCLE_SIZE.large.tablet,
     },
     [media.mobile]: {
-      width: '2.73438rem',
-      height: '2.73438rem',
+      width: LIKERT_CIRCLE_SIZE.large.mobile,
+      height: LIKERT_CIRCLE_SIZE.large.mobile,
     },
   },
 });
@@ -57,27 +58,27 @@ export const circle = recipe({
       position: 'absolute',
       top: '50%',
       left: '50%',
-      width: '1.177rem',
-      height: '1.177rem',
+      width: LIKERT_CENTER_CIRCLE_SIZE.desktop,
+      height: LIKERT_CENTER_CIRCLE_SIZE.desktop,
       borderRadius: '50%',
       backgroundColor: color.brand.gray2,
       transform: 'translate(-50%, -50%)',
-      boxShadow: '0 0 0 0.70625rem #F5F5F5',
+      boxShadow: LIKERT_BOX_SHADOW.unselected.desktop,
     },
 
     '@media': {
       [media.tablet]: {
         '::after': {
-          width: '0.73563rem',
-          height: '0.73563rem',
-          boxShadow: '0 0 0 0.4412rem #F5F5F5',
+          width: LIKERT_CENTER_CIRCLE_SIZE.tablet,
+          height: LIKERT_CENTER_CIRCLE_SIZE.tablet,
+          boxShadow: LIKERT_BOX_SHADOW.unselected.tablet,
         },
       },
       [media.mobile]: {
         '::after': {
-          width: '0.51494rem',
-          height: '0.51494rem',
-          boxShadow: '0 0 0 0.3088rem #F5F5F5',
+          width: LIKERT_CENTER_CIRCLE_SIZE.mobile,
+          height: LIKERT_CENTER_CIRCLE_SIZE.mobile,
+          boxShadow: LIKERT_BOX_SHADOW.unselected.mobile,
         },
       },
     },
@@ -86,33 +87,33 @@ export const circle = recipe({
   variants: {
     size: {
       default: {
-        width: '4.6875rem',
-        height: '4.6875rem',
+        width: LIKERT_CIRCLE_SIZE.default.desktop,
+        height: LIKERT_CIRCLE_SIZE.default.desktop,
 
         '@media': {
           [media.tablet]: {
-            width: '2.92969rem',
-            height: '2.92969rem',
+            width: LIKERT_CIRCLE_SIZE.default.tablet,
+            height: LIKERT_CIRCLE_SIZE.default.tablet,
           },
           [media.mobile]: {
-            width: '2.05081rem',
-            height: '2.05081rem',
+            width: LIKERT_CIRCLE_SIZE.default.mobile,
+            height: LIKERT_CIRCLE_SIZE.default.mobile,
           },
         },
       },
 
       large: {
-        width: '6.25rem',
-        height: '6.25rem',
+        width: LIKERT_CIRCLE_SIZE.large.desktop,
+        height: LIKERT_CIRCLE_SIZE.large.desktop,
 
         '@media': {
           [media.tablet]: {
-            width: '3.90625rem',
-            height: '3.90625rem',
+            width: LIKERT_CIRCLE_SIZE.large.tablet,
+            height: LIKERT_CIRCLE_SIZE.large.tablet,
           },
           [media.mobile]: {
-            width: '2.73438rem',
-            height: '2.73438rem',
+            width: LIKERT_CIRCLE_SIZE.large.mobile,
+            height: LIKERT_CIRCLE_SIZE.large.mobile,
           },
         },
       },
@@ -125,7 +126,7 @@ export const circle = recipe({
         selectors: {
           '&::after': {
             backgroundColor: color.brand.main,
-            boxShadow: '0 0 0 0.70625rem #767A7F',
+            boxShadow: LIKERT_BOX_SHADOW.selected.desktop,
           },
         },
 
@@ -133,14 +134,14 @@ export const circle = recipe({
           [media.tablet]: {
             selectors: {
               '&::after': {
-                boxShadow: '0 0 0 0.4412rem #767A7F',
+                boxShadow: LIKERT_BOX_SHADOW.selected.tablet,
               },
             },
           },
           [media.mobile]: {
             selectors: {
               '&::after': {
-                boxShadow: '0 0 0 0.3088rem #767A7F',
+                boxShadow: LIKERT_BOX_SHADOW.selected.mobile,
               },
             },
           },

--- a/src/app/(main)/balenz-test/questions/components/likertOption/likertOption.css.ts
+++ b/src/app/(main)/balenz-test/questions/components/likertOption/likertOption.css.ts
@@ -1,0 +1,169 @@
+import { color, media, typography } from '@/shared/styles';
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+export const option = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: '0.57rem',
+  cursor: 'pointer',
+
+  '@media': {
+    [media.tablet]: {
+      gap: '0.36rem',
+    },
+    [media.mobile]: {
+      gap: '0.25rem',
+    },
+  },
+});
+
+export const circleWrapper = style({
+  position: 'relative',
+  zIndex: 1,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '6.25rem',
+  height: '6.25rem',
+
+  '@media': {
+    [media.tablet]: {
+      width: '3.90625rem',
+      height: '3.90625rem',
+    },
+    [media.mobile]: {
+      width: '2.73438rem',
+      height: '2.73438rem',
+    },
+  },
+});
+
+export const input = style({
+  display: 'none',
+});
+
+export const circle = recipe({
+  base: {
+    position: 'relative',
+    display: 'block',
+    flexShrink: 0,
+    borderRadius: '50%',
+    backgroundColor: '#D9D9D933',
+
+    '::after': {
+      content: '',
+      position: 'absolute',
+      top: '50%',
+      left: '50%',
+      width: '1.177rem',
+      height: '1.177rem',
+      borderRadius: '50%',
+      backgroundColor: color.brand.gray2,
+      transform: 'translate(-50%, -50%)',
+      boxShadow: '0 0 0 0.70625rem #F5F5F5',
+    },
+
+    '@media': {
+      [media.tablet]: {
+        '::after': {
+          width: '0.73563rem',
+          height: '0.73563rem',
+          boxShadow: '0 0 0 0.4412rem #F5F5F5',
+        },
+      },
+      [media.mobile]: {
+        '::after': {
+          width: '0.51494rem',
+          height: '0.51494rem',
+          boxShadow: '0 0 0 0.3088rem #F5F5F5',
+        },
+      },
+    },
+  },
+
+  variants: {
+    size: {
+      default: {
+        width: '4.6875rem',
+        height: '4.6875rem',
+
+        '@media': {
+          [media.tablet]: {
+            width: '2.92969rem',
+            height: '2.92969rem',
+          },
+          [media.mobile]: {
+            width: '2.05081rem',
+            height: '2.05081rem',
+          },
+        },
+      },
+
+      large: {
+        width: '6.25rem',
+        height: '6.25rem',
+
+        '@media': {
+          [media.tablet]: {
+            width: '3.90625rem',
+            height: '3.90625rem',
+          },
+          [media.mobile]: {
+            width: '2.73438rem',
+            height: '2.73438rem',
+          },
+        },
+      },
+    },
+
+    selected: {
+      true: {
+        backgroundColor: '#1C232B99',
+
+        selectors: {
+          '&::after': {
+            backgroundColor: color.brand.main,
+            boxShadow: '0 0 0 0.70625rem #767A7F',
+          },
+        },
+
+        '@media': {
+          [media.tablet]: {
+            selectors: {
+              '&::after': {
+                boxShadow: '0 0 0 0.4412rem #767A7F',
+              },
+            },
+          },
+          [media.mobile]: {
+            selectors: {
+              '&::after': {
+                boxShadow: '0 0 0 0.3088rem #767A7F',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+});
+
+export const label = style({
+  display: 'block',
+  minHeight: '1.5em',
+  color: color.text.tertiary,
+  ...typography.desktop.body2,
+
+  '@media': {
+    [media.tablet]: {
+      minHeight: '1.4em',
+      ...typography.tablet.body3,
+    },
+    [media.mobile]: {
+      minHeight: '1.4em',
+      ...typography.phone.body3,
+    },
+  },
+});

--- a/src/app/(main)/balenz-test/questions/constants/likertOption.ts
+++ b/src/app/(main)/balenz-test/questions/constants/likertOption.ts
@@ -1,0 +1,32 @@
+import { LikertOptionData } from '../types/likert';
+
+export const LIKERT_OPTIONS = [
+  {
+    value: 1,
+    label: '매우 반대',
+    size: 'large',
+  },
+  {
+    value: 2,
+    size: 'default',
+  },
+  {
+    value: 3,
+    label: '약간 반대',
+    size: 'default',
+  },
+  {
+    value: 4,
+    label: '약간 동의',
+    size: 'default',
+  },
+  {
+    value: 5,
+    size: 'default',
+  },
+  {
+    value: 6,
+    label: '매우 동의',
+    size: 'large',
+  },
+] as const satisfies readonly LikertOptionData[];

--- a/src/app/(main)/balenz-test/questions/types/likert.ts
+++ b/src/app/(main)/balenz-test/questions/types/likert.ts
@@ -1,0 +1,13 @@
+/**
+ * 리커트 응답값과 UI 크기 타입 정의
+ */
+
+export type LikertValue = 1 | 2 | 3 | 4 | 5 | 6;
+
+export type LikertOptionSize = 'default' | 'large';
+
+export interface LikertOptionData {
+  value: LikertValue;
+  label?: string;
+  size: LikertOptionSize;
+}


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #191 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- 정치 성향 테스트 문항 응답에 사용하는 `LikertOption` 컴포넌트를 구현
- 각 응답 옵션은 `radio input` 기반으로 동작하며, 선택 여부에 따라 원형 UI가 변경되도록 구성
- `LikertValue`, `LikertOptionSize`, `LikertOptionData` 타입을 정의해 리커트 응답값과 옵션 데이터를 타입 안정성 있게 관리
- 리커트 척도 옵션 데이터를 `LIKERT_OPTIONS` 상수로 분리
  - `value`: 응답 값
  - `label`: 화면에 노출되는 라벨
  - `size`: 원형 옵션 크기
- 데스크톱, 태블릿, 모바일 환경에 맞춰 원 크기, 가운데 원 크기, ring 크기, 라벨 타이포그래피를 반응형으로 적용
- 라벨이 없는 옵션도 동일한 높이를 차지하도록 처리해 옵션 간 세로 정렬이 어긋나지 않도록 보정
- `LikertOption` 관련 복잡한 스타일 상수들을 분리


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
- 리커트 옵션 데이터는 `constants/likertOption.ts`에서 관리합니다.
- 응답값과 옵션 크기 타입은 `types/likert.ts`에서 관리합니다.
- 원형 옵션 스타일은 `recipe`의 `size`, `selected` variant로 분리했습니다.
- 라벨이 없는 옵션도 빈 문자열로 렌더링되며, 라벨 영역 높이를 유지해 전체 정렬이 깨지지 않도록 했습니다.

### LikertOption 컴포넌트 사용방법
```tsx
import { useState } from 'react';

import LikertOption from './components/likertOption/LikertOption';
import { LIKERT_OPTIONS } from './constants/likertOption';
import type { LikertValue } from './types/likert';

export default function Page() {
  const [selectedValue, setSelectedValue] = useState<LikertValue>();

  return (
    <div>
      {LIKERT_OPTIONS.map((option) => (
        <LikertOption
          key={option.value}
          name="political-test-question"
          option={option}
          checked={selectedValue === option.value}
          onChange={setSelectedValue}
        />
      ))}
    </div>
  );
}
```


- name: 같은 질문의 라디오 버튼을 하나의 그룹으로 묶는 이름
- option: 선택지의 값, 라벨, 크기 등의 정보
- checked: 현재 선택된 값과 해당 선택지 값이 같은지 여부
- onChange: 선택 시 값이 변경됐을 때 실행할 이벤트 핸들러 함수



## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| Desktop | Tablet | Mobile |
|--|--|--|
| <img width="605" height="165" alt="스크린샷 2026-07-17 오전 4 16 06" src="https://github.com/user-attachments/assets/cc12ff0c-5dd3-4260-bacc-028fd027e78d" /> | <img width="397" height="122" alt="스크린샷 2026-07-17 오전 4 16 29" src="https://github.com/user-attachments/assets/8e9b448c-7a13-4905-bdf2-74196b507031" /> | <img width="223" height="80" alt="스크린샷 2026-07-17 오전 4 16 58" src="https://github.com/user-attachments/assets/ebf8356a-5d10-4c53-bf72-3a82ae6a57e9" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - Balenz 테스트에 1~6점 척도의 리커트 설문 응답 옵션을 추가했습니다.
  - 응답 선택 상태를 명확히 보여주는 원형 라디오 버튼 UI를 제공합니다.
  - 선택지별 크기와 설명 문구를 지원하며, 화면 크기에 맞춰 표시 방식이 조정됩니다.
  - 키보드와 라벨 영역을 통한 선택을 지원해 더욱 편리하게 응답할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->