### PR TITLE
[Feat] LikertScale 컴포넌트 구현

### DIFF
--- a/src/app/(main)/balenz-test/questions/components/likertOption/LikertOption.tsx
+++ b/src/app/(main)/balenz-test/questions/components/likertOption/LikertOption.tsx
@@ -1,0 +1,36 @@
+import type { LikertOptionData, LikertValue } from '../../types/likert';
+
+import * as styles from './likertOption.css';
+
+interface LikertOptionPropTypes {
+  name: string;
+  option: LikertOptionData;
+  checked: boolean;
+  onChange: (value: LikertValue) => void;
+}
+
+const LikertOption = ({ name, option, checked, onChange }: LikertOptionPropTypes) => {
+  const inputId = `${name}-${option.value}`;
+
+  return (
+    <label htmlFor={inputId} className={styles.option}>
+      <input
+        id={inputId}
+        className={styles.input}
+        type="radio"
+        name={name}
+        value={option.value}
+        checked={checked}
+        onChange={() => onChange(option.value)}
+      />
+
+      <span className={styles.circleWrapper}>
+        <span className={styles.circle({ size: option.size, selected: checked })} />
+      </span>
+
+      <span className={styles.label}>{option.label ?? ''}</span>
+    </label>
+  );
+};
+
+export default LikertOption;

--- a/src/app/(main)/balenz-test/questions/components/likertOption/constants.ts
+++ b/src/app/(main)/balenz-test/questions/components/likertOption/constants.ts
@@ -1,0 +1,38 @@
+/**
+ * LikertOption 컴포넌트 스타일 관련 상수
+ */
+
+// 전체 원 크기
+export const LIKERT_CIRCLE_SIZE = {
+  large: {
+    desktop: '6.25rem',
+    tablet: '3.90625rem',
+    mobile: '2.73438rem',
+  },
+  default: {
+    desktop: '4.6875rem',
+    tablet: '2.92969rem',
+    mobile: '2.05081rem',
+  },
+} as const;
+
+// 중심 작은 원 크기
+export const LIKERT_CENTER_CIRCLE_SIZE = {
+  desktop: '1.177rem',
+  tablet: '0.73563rem',
+  mobile: '0.51494rem',
+} as const;
+
+// 중심 원의 box shadow 크기 및 색상
+export const LIKERT_BOX_SHADOW = {
+  selected: {
+    desktop: '0 0 0 0.70625rem #767A7F',
+    tablet: '0 0 0 0.4412rem #767A7F',
+    mobile: '0 0 0 0.3088rem #767A7F',
+  },
+  unselected: {
+    desktop: '0 0 0 0.70625rem #F5F5F5',
+    tablet: '0 0 0 0.4412rem #F5F5F5',
+    mobile: '0 0 0 0.3088rem #F5F5F5',
+  },
+} as const;

--- a/src/app/(main)/balenz-test/questions/components/likertOption/likertOption.css.ts
+++ b/src/app/(main)/balenz-test/questions/components/likertOption/likertOption.css.ts
@@ -1,6 +1,7 @@
 import { color, media, typography } from '@/shared/styles';
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
+import { LIKERT_BOX_SHADOW, LIKERT_CENTER_CIRCLE_SIZE, LIKERT_CIRCLE_SIZE } from './constants';
 
 export const option = style({
   display: 'flex',
@@ -25,17 +26,17 @@ export const circleWrapper = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  width: '6.25rem',
-  height: '6.25rem',
+  width: LIKERT_CIRCLE_SIZE.large.desktop,
+  height: LIKERT_CIRCLE_SIZE.large.desktop,
 
   '@media': {
     [media.tablet]: {
-      width: '3.90625rem',
-      height: '3.90625rem',
+      width: LIKERT_CIRCLE_SIZE.large.tablet,
+      height: LIKERT_CIRCLE_SIZE.large.tablet,
     },
     [media.mobile]: {
-      width: '2.73438rem',
-      height: '2.73438rem',
+      width: LIKERT_CIRCLE_SIZE.large.mobile,
+      height: LIKERT_CIRCLE_SIZE.large.mobile,
     },
   },
 });
@@ -57,27 +58,27 @@ export const circle = recipe({
       position: 'absolute',
       top: '50%',
       left: '50%',
-      width: '1.177rem',
-      height: '1.177rem',
+      width: LIKERT_CENTER_CIRCLE_SIZE.desktop,
+      height: LIKERT_CENTER_CIRCLE_SIZE.desktop,
       borderRadius: '50%',
       backgroundColor: color.brand.gray2,
       transform: 'translate(-50%, -50%)',
-      boxShadow: '0 0 0 0.70625rem #F5F5F5',
+      boxShadow: LIKERT_BOX_SHADOW.unselected.desktop,
     },
 
     '@media': {
       [media.tablet]: {
         '::after': {
-          width: '0.73563rem',
-          height: '0.73563rem',
-          boxShadow: '0 0 0 0.4412rem #F5F5F5',
+          width: LIKERT_CENTER_CIRCLE_SIZE.tablet,
+          height: LIKERT_CENTER_CIRCLE_SIZE.tablet,
+          boxShadow: LIKERT_BOX_SHADOW.unselected.tablet,
         },
       },
       [media.mobile]: {
         '::after': {
-          width: '0.51494rem',
-          height: '0.51494rem',
-          boxShadow: '0 0 0 0.3088rem #F5F5F5',
+          width: LIKERT_CENTER_CIRCLE_SIZE.mobile,
+          height: LIKERT_CENTER_CIRCLE_SIZE.mobile,
+          boxShadow: LIKERT_BOX_SHADOW.unselected.mobile,
         },
       },
     },
@@ -86,33 +87,33 @@ export const circle = recipe({
   variants: {
     size: {
       default: {
-        width: '4.6875rem',
-        height: '4.6875rem',
+        width: LIKERT_CIRCLE_SIZE.default.desktop,
+        height: LIKERT_CIRCLE_SIZE.default.desktop,
 
         '@media': {
           [media.tablet]: {
-            width: '2.92969rem',
-            height: '2.92969rem',
+            width: LIKERT_CIRCLE_SIZE.default.tablet,
+            height: LIKERT_CIRCLE_SIZE.default.tablet,
           },
           [media.mobile]: {
-            width: '2.05081rem',
-            height: '2.05081rem',
+            width: LIKERT_CIRCLE_SIZE.default.mobile,
+            height: LIKERT_CIRCLE_SIZE.default.mobile,
           },
         },
       },
 
       large: {
-        width: '6.25rem',
-        height: '6.25rem',
+        width: LIKERT_CIRCLE_SIZE.large.desktop,
+        height: LIKERT_CIRCLE_SIZE.large.desktop,
 
         '@media': {
           [media.tablet]: {
-            width: '3.90625rem',
-            height: '3.90625rem',
+            width: LIKERT_CIRCLE_SIZE.large.tablet,
+            height: LIKERT_CIRCLE_SIZE.large.tablet,
           },
           [media.mobile]: {
-            width: '2.73438rem',
-            height: '2.73438rem',
+            width: LIKERT_CIRCLE_SIZE.large.mobile,
+            height: LIKERT_CIRCLE_SIZE.large.mobile,
           },
         },
       },
@@ -125,7 +126,7 @@ export const circle = recipe({
         selectors: {
           '&::after': {
             backgroundColor: color.brand.main,
-            boxShadow: '0 0 0 0.70625rem #767A7F',
+            boxShadow: LIKERT_BOX_SHADOW.selected.desktop,
           },
         },
 
@@ -133,14 +134,14 @@ export const circle = recipe({
           [media.tablet]: {
             selectors: {
               '&::after': {
-                boxShadow: '0 0 0 0.4412rem #767A7F',
+                boxShadow: LIKERT_BOX_SHADOW.selected.tablet,
               },
             },
           },
           [media.mobile]: {
             selectors: {
               '&::after': {
-                boxShadow: '0 0 0 0.3088rem #767A7F',
+                boxShadow: LIKERT_BOX_SHADOW.selected.mobile,
               },
             },
           },

--- a/src/app/(main)/balenz-test/questions/components/likertOption/likertOption.css.ts
+++ b/src/app/(main)/balenz-test/questions/components/likertOption/likertOption.css.ts
@@ -1,0 +1,169 @@
+import { color, media, typography } from '@/shared/styles';
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+export const option = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: '0.57rem',
+  cursor: 'pointer',
+
+  '@media': {
+    [media.tablet]: {
+      gap: '0.36rem',
+    },
+    [media.mobile]: {
+      gap: '0.25rem',
+    },
+  },
+});
+
+export const circleWrapper = style({
+  position: 'relative',
+  zIndex: 1,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '6.25rem',
+  height: '6.25rem',
+
+  '@media': {
+    [media.tablet]: {
+      width: '3.90625rem',
+      height: '3.90625rem',
+    },
+    [media.mobile]: {
+      width: '2.73438rem',
+      height: '2.73438rem',
+    },
+  },
+});
+
+export const input = style({
+  display: 'none',
+});
+
+export const circle = recipe({
+  base: {
+    position: 'relative',
+    display: 'block',
+    flexShrink: 0,
+    borderRadius: '50%',
+    backgroundColor: '#D9D9D933',
+
+    '::after': {
+      content: '',
+      position: 'absolute',
+      top: '50%',
+      left: '50%',
+      width: '1.177rem',
+      height: '1.177rem',
+      borderRadius: '50%',
+      backgroundColor: color.brand.gray2,
+      transform: 'translate(-50%, -50%)',
+      boxShadow: '0 0 0 0.70625rem #F5F5F5',
+    },
+
+    '@media': {
+      [media.tablet]: {
+        '::after': {
+          width: '0.73563rem',
+          height: '0.73563rem',
+          boxShadow: '0 0 0 0.4412rem #F5F5F5',
+        },
+      },
+      [media.mobile]: {
+        '::after': {
+          width: '0.51494rem',
+          height: '0.51494rem',
+          boxShadow: '0 0 0 0.3088rem #F5F5F5',
+        },
+      },
+    },
+  },
+
+  variants: {
+    size: {
+      default: {
+        width: '4.6875rem',
+        height: '4.6875rem',
+
+        '@media': {
+          [media.tablet]: {
+            width: '2.92969rem',
+            height: '2.92969rem',
+          },
+          [media.mobile]: {
+            width: '2.05081rem',
+            height: '2.05081rem',
+          },
+        },
+      },
+
+      large: {
+        width: '6.25rem',
+        height: '6.25rem',
+
+        '@media': {
+          [media.tablet]: {
+            width: '3.90625rem',
+            height: '3.90625rem',
+          },
+          [media.mobile]: {
+            width: '2.73438rem',
+            height: '2.73438rem',
+          },
+        },
+      },
+    },
+
+    selected: {
+      true: {
+        backgroundColor: '#1C232B99',
+
+        selectors: {
+          '&::after': {
+            backgroundColor: color.brand.main,
+            boxShadow: '0 0 0 0.70625rem #767A7F',
+          },
+        },
+
+        '@media': {
+          [media.tablet]: {
+            selectors: {
+              '&::after': {
+                boxShadow: '0 0 0 0.4412rem #767A7F',
+              },
+            },
+          },
+          [media.mobile]: {
+            selectors: {
+              '&::after': {
+                boxShadow: '0 0 0 0.3088rem #767A7F',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+});
+
+export const label = style({
+  display: 'block',
+  minHeight: '1.5em',
+  color: color.text.tertiary,
+  ...typography.desktop.body2,
+
+  '@media': {
+    [media.tablet]: {
+      minHeight: '1.4em',
+      ...typography.tablet.body3,
+    },
+    [media.mobile]: {
+      minHeight: '1.4em',
+      ...typography.phone.body3,
+    },
+  },
+});

--- a/src/app/(main)/balenz-test/questions/components/likertScale/LikertScale.tsx
+++ b/src/app/(main)/balenz-test/questions/components/likertScale/LikertScale.tsx
@@ -1,0 +1,31 @@
+import { LIKERT_OPTIONS } from '../../constants/likertOption';
+import type { LikertValue } from '../../types/likert';
+import LikertOption from '../likertOption/LikertOption';
+
+import * as styles from './likertScale.css';
+
+interface LikertScalePropTypes {
+  questionId: number | string;
+  value?: LikertValue;
+  onChange: (value: LikertValue) => void;
+}
+
+const LikertScale = ({ questionId, value, onChange }: LikertScalePropTypes) => {
+  const inputName = `question-${questionId}`;
+
+  return (
+    <div className={styles.scale} role="radiogroup" aria-label="응답 선택">
+      {LIKERT_OPTIONS.map((option) => (
+        <LikertOption
+          key={option.value}
+          name={inputName}
+          option={option}
+          checked={value === option.value}
+          onChange={onChange}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default LikertScale;

--- a/src/app/(main)/balenz-test/questions/components/likertScale/likertScale.css.ts
+++ b/src/app/(main)/balenz-test/questions/components/likertScale/likertScale.css.ts
@@ -1,0 +1,36 @@
+import { style } from '@vanilla-extract/css';
+import { media } from '@/shared/styles';
+
+export const scale = style({
+  position: 'relative',
+  display: 'grid',
+  gridTemplateColumns: 'repeat(6, minmax(0, 1fr))',
+  alignItems: 'center',
+  width: '100%',
+  margin: '0 auto',
+
+  '::before': {
+    content: '',
+    position: 'absolute',
+    top: '3.125rem',
+    left: '8.333%',
+    right: '8.333%',
+    height: '0.2069rem',
+    backgroundColor: '#dedede',
+  },
+
+  '@media': {
+    [media.tablet]: {
+      '::before': {
+        top: '1.95313rem',
+        height: '0.075rem',
+      },
+    },
+    [media.mobile]: {
+      '::before': {
+        top: '1.36719rem',
+        height: '0.075rem',
+      },
+    },
+  },
+});

--- a/src/app/(main)/balenz-test/questions/constants/likertOption.ts
+++ b/src/app/(main)/balenz-test/questions/constants/likertOption.ts
@@ -1,0 +1,32 @@
+import { LikertOptionData } from '../types/likert';
+
+export const LIKERT_OPTIONS = [
+  {
+    value: 1,
+    label: '매우 반대',
+    size: 'large',
+  },
+  {
+    value: 2,
+    size: 'default',
+  },
+  {
+    value: 3,
+    label: '약간 반대',
+    size: 'default',
+  },
+  {
+    value: 4,
+    label: '약간 동의',
+    size: 'default',
+  },
+  {
+    value: 5,
+    size: 'default',
+  },
+  {
+    value: 6,
+    label: '매우 동의',
+    size: 'large',
+  },
+] as const satisfies readonly LikertOptionData[];

--- a/src/app/(main)/balenz-test/questions/types/likert.ts
+++ b/src/app/(main)/balenz-test/questions/types/likert.ts
@@ -1,0 +1,13 @@
+/**
+ * 리커트 응답값과 UI 크기 타입 정의
+ */
+
+export type LikertValue = 1 | 2 | 3 | 4 | 5 | 6;
+
+export type LikertOptionSize = 'default' | 'large';
+
+export interface LikertOptionData {
+  value: LikertValue;
+  label?: string;
+  size: LikertOptionSize;
+}


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #196 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->

- 정치 성향 테스트 문항 응답에 사용하는 `LikertScale` 컴포넌트를 구현
- `LIKERT_OPTIONS` 상수를 기반으로 6개의 `LikertOption`을 렌더링하도록 구성
- `questionId`를 사용해 각 문항별 radio `name`을 생성하도록 처리
  - 문항마다 독립적인 radio group으로 동작할 수 있도록 구성
- 현재 선택된 응답값을 `value` prop으로 전달받고, 각 옵션의 `checked` 상태를 비교해 제어하도록 구현
- 옵션 선택 시 `onChange`를 통해 선택된 `LikertValue`를 상위 컴포넌트로 전달하도록 구성
- `role="radiogroup"`과 `aria-label`을 추가해 리커트 척도 영역의 의미를 명확히 정의
- `grid` 레이아웃을 사용해 6개의 선택지를 동일한 간격으로 가로 배치
- `::before` pseudo element를 사용해 선택지 사이를 잇는 가로 라인을 구현
- 데스크톱, 태블릿, 모바일 환경에 맞춰 라인의 위치와 두께를 반응형으로 조정

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->

- `LikertScale`은 개별 옵션 UI를 직접 그리지 않고, `LikertOption`을 조합하는 wrapper 역할을 합니다.
- 옵션 데이터는 `constants/likertOption.ts`의 `LIKERT_OPTIONS`를 사용합니다.
- 선택 상태는 내부 state로 관리하지 않고, `value`와 `onChange`를 통해 외부에서 제어하는 controlled component 방식으로 구성했습니다.
- 가로 연결선은 `likertScale.css.ts`의 `scale::before`에서 관리합니다.

### LikertScale 컴포넌트 사용방법

```tsx
import { useState } from 'react';

import LikertScale from './components/likertScale/LikertScale';
import type { LikertValue } from './types/likert';

export default function Page() {
  const [selectedValue, setSelectedValue] = useState<LikertValue>();

  return (
    <div>
      <LikertScale questionId="test-question-1" value={selectedValue} onChange={setSelectedValue} />
    </div>
  );
}
```

- questionId: 각 질문을 구분하는 고유 ID로, 라디오 그룹의 name 생성 등에 사용
- value: 현재 선택된 응답 값. 아직 선택하지 않았다면 undefined
- onChange: 선택지가 변경될 때 선택된 값을 상위 컴포넌트로 전달하는 이벤트 핸들러

## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| Desktop | Tablet | Mobile |
|--|--|--|
| <img width="810" height="180" alt="스크린샷 2026-07-17 오전 4 28 10" src="https://github.com/user-attachments/assets/0a00eb86-f2c4-43e4-8b54-885df364ed0c" /> | <img width="502" height="116" alt="스크린샷 2026-07-17 오전 4 28 38" src="https://github.com/user-attachments/assets/b0eeecd0-9f54-46f3-b259-d2336c4521d3" /> | <img width="286" height="72" alt="스크린샷 2026-07-17 오전 4 28 57" src="https://github.com/user-attachments/assets/b5d4d8a9-1ab8-4c72-be18-850813771600" /> |
