### PR TITLE
[Feat] StepNavigation 컴포넌트 구현

### DIFF
--- a/src/app/(main)/balenz-test/profile/components/stepNavigation/StepNavigation.tsx
+++ b/src/app/(main)/balenz-test/profile/components/stepNavigation/StepNavigation.tsx
@@ -1,0 +1,69 @@
+import Image from 'next/image';
+
+import * as styles from './stepNavigation.css';
+
+interface StepNavigationPropTypes {
+  showPrevious?: boolean;
+  showSkip?: boolean;
+  isNextDisabled?: boolean;
+  onPrevious?: () => void;
+  onNext: () => void;
+  onSkip?: () => void;
+}
+
+const StepNavigation = ({
+  showPrevious = true,
+  showSkip = true,
+  isNextDisabled = false,
+  onPrevious,
+  onNext,
+  onSkip,
+}: StepNavigationPropTypes) => {
+  return (
+    <nav className={styles.container} aria-label="단계 이동">
+      <div className={styles.previousArea}>
+        {showPrevious && (
+          <button type="button" className={styles.previousBtn} onClick={onPrevious}>
+            <Image
+              src="/icons/ic_arrow_left_gray.svg"
+              alt=""
+              width={20}
+              height={20}
+              className={styles.arrowIcon}
+              aria-hidden
+            />
+
+            <span>이전</span>
+          </button>
+        )}
+      </div>
+
+      <div className={styles.rightArea}>
+        {showSkip && (
+          <button type="button" className={styles.skipBtn} onClick={onSkip}>
+            건너뛰기
+          </button>
+        )}
+
+        <button type="button" className={styles.nextBtn} disabled={isNextDisabled} onClick={onNext}>
+          <span>다음</span>
+
+          <Image
+            src={
+              isNextDisabled
+                ? '/icons/ic_arrow_right_inactive.svg'
+                : '/icons/ic_arrow_right_active.svg'
+            }
+            alt=""
+            width={20}
+            height={20}
+            className={styles.arrowIcon}
+            aria-hidden
+          />
+        </button>
+      </div>
+    </nav>
+  );
+};
+
+export default StepNavigation;

--- a/src/app/(main)/balenz-test/profile/components/stepNavigation/stepNavigation.css.ts
+++ b/src/app/(main)/balenz-test/profile/components/stepNavigation/stepNavigation.css.ts
@@ -1,0 +1,136 @@
+import { style } from '@vanilla-extract/css';
+
+import { color, media, typography } from '@/shared/styles';
+
+export const container = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+
+  width: '100%',
+
+  '@media': {
+    [media.mobile]: {
+      justifyContent: 'space-between',
+    },
+  },
+});
+
+export const previousArea = style({
+  display: 'flex',
+  alignItems: 'center',
+
+  '@media': {
+    [media.mobile]: {
+      display: 'contents',
+    },
+  },
+});
+
+export const rightArea = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.625rem',
+
+  '@media': {
+    [media.mobile]: {
+      display: 'contents',
+    },
+  },
+});
+
+export const previousBtn = style({
+  ...typography.desktop.h4,
+
+  display: 'flex',
+  alignItems: 'center',
+  gap: '1.88rem',
+
+  padding: '0.625rem 0',
+
+  color: color.text.secondary,
+  backgroundColor: 'transparent',
+  border: 0,
+
+  cursor: 'pointer',
+
+  '@media': {
+    [media.tablet]: {
+      ...typography.tablet.h4,
+    },
+
+    [media.mobile]: {
+      ...typography.phone.h3,
+
+      padding: '0.625rem 1.25rem',
+    },
+  },
+});
+
+export const skipBtn = style({
+  ...typography.desktop.h4,
+
+  padding: '0.625rem 1.25rem',
+
+  color: color.text.tertiary,
+  backgroundColor: 'transparent',
+  border: 0,
+
+  cursor: 'pointer',
+
+  '@media': {
+    [media.tablet]: {
+      ...typography.tablet.h4,
+    },
+
+    [media.mobile]: {
+      ...typography.phone.h3,
+    },
+  },
+});
+
+export const nextBtn = style({
+  ...typography.desktop.h4,
+
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '1.88rem',
+
+  padding: '0.625rem 1.25rem',
+
+  color: color.text.inverse,
+  backgroundColor: color.brand.main,
+  border: 0,
+  borderRadius: '0.4375rem',
+
+  cursor: 'pointer',
+
+  selectors: {
+    '&:disabled': {
+      color: color.text.disabled,
+      backgroundColor: 'transparent',
+      cursor: 'default',
+    },
+
+    '&:focus-visible': {
+      outline: `1px solid ${color.brand.main}`,
+    },
+  },
+
+  '@media': {
+    [media.tablet]: {
+      ...typography.tablet.h4,
+    },
+
+    [media.mobile]: {
+      ...typography.phone.h3,
+    },
+  },
+});
+
+export const arrowIcon = style({
+  width: '1.25rem',
+  height: '1.25rem',
+  flexShrink: 0,
+});


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #200 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- 정치 성향 테스트의 단계 이동에 사용되는 StepNavigation 컴포넌트를 구현했습니다.
- 이전, 다음, 건너뛰기 버튼을 구성하고 각 버튼의 클릭 이벤트를 props로 전달받도록 구현했습니다.
- showPrevious, showSkip props를 통해 이전 및 건너뛰기 버튼의 노출 여부를 제어할 수 있도록 했습니다.
- isNextDisabled 상태에 따라 다음 버튼의 활성화 여부와 화살표 아이콘이 변경되도록 적용했습니다.
- 데스크톱, 태블릿, 모바일 환경에 맞춰 타이포그래피와 버튼 배치를 반응형으로 구현했습니다.
- 단계 이동 영역에 nav 태그와 aria-label을 적용하고, 장식용 아이콘은 스크린 리더에서 제외했습니다.

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
#### StepNavigation 컴포넌트 사용 방법
- StepNavigation은 버튼 노출 여부(showPrevious, showSkip), 다음 버튼 활성화 상태(isNextDisabled), 그리고 각 버튼의 이벤트 핸들러(onPrevious, onNext, onSkip)를 props로 전달하여 사용하는 공통 컴포넌트입니다.

```ts
<StepNavigation
  showPrevious
  showSkip={!isBirthYearStep}
  isNextDisabled={!isBirthYearStep && selectedGender === null}
  onPrevious={handlePrevious}
  onNext={handleNext}
  onSkip={handleSkip}
/>
```

## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| <img width="741" height="77" alt="스크린샷 2026-07-17 오후 11 34 34" src="https://github.com/user-attachments/assets/80cc92d0-f99c-497f-82d0-5529a9bdcbd1" /> | <img width="726" height="102" alt="스크린샷 2026-07-17 오후 11 35 28" src="https://github.com/user-attachments/assets/ed03346e-d84b-43a4-8fa8-e757056526b0" /> | 
