### PR TITLE
[Feat] QuestionItem 컴포넌트 구현

### DIFF
--- a/src/app/(main)/balenz-test/questions/components/questionItem/QuestionItem.tsx
+++ b/src/app/(main)/balenz-test/questions/components/questionItem/QuestionItem.tsx
@@ -1,0 +1,27 @@
+import type { LikertValue } from '../../types/likert';
+import LikertScale from '../likertScale/LikertScale';
+
+import * as styles from './questionItem.css';
+
+interface QuestionItemPropTypes {
+  questionId: number | string;
+  question: string;
+  value?: LikertValue;
+  onChange: (questionId: number | string, value: LikertValue) => void;
+}
+
+const QuestionItem = ({ questionId, question, value, onChange }: QuestionItemPropTypes) => {
+  const handleChange = (selectedValue: LikertValue) => {
+    onChange(questionId, selectedValue);
+  };
+
+  return (
+    <fieldset className={styles.container}>
+      <legend className={styles.question}>{question}</legend>
+
+      <LikertScale questionId={questionId} value={value} onChange={handleChange} />
+    </fieldset>
+  );
+};
+
+export default QuestionItem;

--- a/src/app/(main)/balenz-test/questions/components/questionItem/questionItem.css.ts
+++ b/src/app/(main)/balenz-test/questions/components/questionItem/questionItem.css.ts
@@ -1,0 +1,24 @@
+import { color, media, typography } from '@/shared/styles';
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  width: '100%',
+  margin: 0,
+  border: 0,
+});
+
+export const question = style({
+  width: '100%',
+  marginBottom: '1.88rem',
+  padding: 0,
+
+  color: color.text.main,
+  ...typography.desktop.h3,
+  textAlign: 'center',
+  wordBreak: 'keep-all',
+
+  '@media': {
+    [media.tablet]: typography.tablet.h3,
+    [media.mobile]: typography.phone.h3,
+  },
+});


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #198 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- QuestionItem 컴포넌트를 구현
- 각 문항의 질문 텍스트와 리커트 척도 선택 영역을 함께 렌더링하도록 구성
- `questionId`, `question`, `value`, `onChange` props를 받아 상위 컴포넌트에서 응답 상태를 제어할 수 있도록 구현
- `onChange`는 문항 ID와 선택값을 함께 전달하도록 연결해, 여러 질문의 응답을 일관된 방식으로 관리
- `questionItem.css.ts`에서 질문 영역의 레이아웃과 타이포그래피를 정리해, 화면 크기에 따라 자연스럽게 보이도록 반응형 스타일을 적용
- 접근성을 위해 fieldset과 legend 구조를 사용해 질문 단위를 의미적으로 구분


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
#### QuestionItem 컴포넌트 사용 방법
- `QuestionItem`은 질문 텍스트, 현재 선택값, 변경 핸들러를 props로 전달받아 사용하는 공통 질문 단위 컴포넌트입니다.
- 상위 컴포넌트에서 각 질문의 응답 상태를 보관하고, `onChange`를 통해 질문 ID와 선택값을 함께 전달받아 상태를 갱신하는 방식으로 사용합니다.

```tsx
<QuestionItem
        questionId={question.id}
        question={question.content}
        value={answers[question.id]}
        onChange={onAnswerChange}
/>
```

- `questionId`: 질문 ID
- `question`: 화면에 표시할 질문 문구
- `value`: 현재 선택된 리커트 값
- `onChange`: 질문 ID와 선택값을 전달받는 핸들러


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
<img width="527" height="186" alt="스크린샷 2026-07-18 오전 4 36 38" src="https://github.com/user-attachments/assets/9b49d111-f9dc-420b-9db2-3948189e6738" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 질문 텍스트와 Likert 척도 선택지를 표시하는 질문 항목을 추가했습니다.
  * 척도 선택 변경 사항이 상위 화면으로 전달됩니다.
  * 데스크톱, 태블릿, 모바일 환경에 맞춘 질문 레이아웃과 텍스트 스타일을 적용했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->