### PR TITLE
[Feat] BirthYearSlider 컴포넌트 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@vanilla-extract/css": "^1.20.0",
     "@vanilla-extract/recipes": "^0.5.7",
     "embla-carousel-react": "^8.6.0",
+    "embla-carousel-wheel-gestures": "^8.1.0",
     "next": "16.1.7",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@19.2.3)
+      embla-carousel-wheel-gestures:
+        specifier: ^8.1.0
+        version: 8.1.0(embla-carousel@8.6.0)
       next:
         specifier: 16.1.7
         version: 16.1.7(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1625,6 +1628,12 @@ packages:
     peerDependencies:
       embla-carousel: 8.6.0
 
+  embla-carousel-wheel-gestures@8.1.0:
+    resolution: {integrity: sha512-J68jkYrxbWDmXOm2n2YHl+uMEXzkGSKjWmjaEgL9xVvPb3HqVmg6rJSKfI3sqIDVvm7mkeTy87wtG/5263XqHQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      embla-carousel: ^8.0.0 || ~8.0.0-rc03
+
   embla-carousel@8.6.0:
     resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
 
@@ -2972,6 +2981,10 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  wheel-gestures@2.2.48:
+    resolution: {integrity: sha512-f+Gy33Oa5Z14XY9679Zze+7VFhbsQfBFXodnU2x589l4kxGM9L5Y8zETTmcMR5pWOPQyRv4Z0lNax6xCO0NSlA==}
+    engines: {node: '>=18'}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -4502,6 +4515,11 @@ snapshots:
   embla-carousel-reactive-utils@8.6.0(embla-carousel@8.6.0):
     dependencies:
       embla-carousel: 8.6.0
+
+  embla-carousel-wheel-gestures@8.1.0(embla-carousel@8.6.0):
+    dependencies:
+      embla-carousel: 8.6.0
+      wheel-gestures: 2.2.48
 
   embla-carousel@8.6.0: {}
 
@@ -6113,6 +6131,8 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  wheel-gestures@2.2.48: {}
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/src/app/(main)/balenz-test/profile/components/birthYearSlider/BirthYearSlider.tsx
+++ b/src/app/(main)/balenz-test/profile/components/birthYearSlider/BirthYearSlider.tsx
@@ -321,8 +321,7 @@ const BirthYearSlider = ({
                       const isCommitted = commitInput();
 
                       if (!isCommitted) {
-                        setDraftYear(String(selectedYear));
-                        setIsEditing(false);
+                        cancelEditing();
                       }
                     }}
                   />

--- a/src/app/(main)/balenz-test/profile/components/birthYearSlider/BirthYearSlider.tsx
+++ b/src/app/(main)/balenz-test/profile/components/birthYearSlider/BirthYearSlider.tsx
@@ -151,16 +151,6 @@ const BirthYearSlider = ({
     viewportRef.current?.focus({ preventScroll: true });
   }, []);
 
-  const handleViewportBlur = () => {
-    if (isEditing) {
-      return;
-    }
-
-    requestAnimationFrame(() => {
-      viewportRef.current?.focus({ preventScroll: true });
-    });
-  };
-
   /**
    * 선택된 가운데 연도를 직접 입력 모드로 전환
    */
@@ -292,7 +282,6 @@ const BirthYearSlider = ({
         role="group"
         aria-label={`출생 연도 선택. 현재 선택된 연도는 ${selectedYear}년입니다.`}
         onKeyDown={handleSliderKeyDown}
-        onBlur={handleViewportBlur}
       >
         <div className={styles.container}>
           {years.map((year) => {

--- a/src/app/(main)/balenz-test/profile/components/birthYearSlider/BirthYearSlider.tsx
+++ b/src/app/(main)/balenz-test/profile/components/birthYearSlider/BirthYearSlider.tsx
@@ -198,7 +198,8 @@ const BirthYearSlider = ({
 
   const adjustDraftYear = useCallback(
     (delta: number) => {
-      const nextYear = clampYear(Number(draftYear || selectedYear) + delta, minYear, maxYear);
+      const baseYear = /^\d{4}$/.test(draftYear) ? Number(draftYear) : selectedYear;
+      const nextYear = clampYear(baseYear + delta, minYear, maxYear);
 
       setDraftYear(String(nextYear));
       setErrorMessage('');

--- a/src/app/(main)/balenz-test/profile/components/birthYearSlider/BirthYearSlider.tsx
+++ b/src/app/(main)/balenz-test/profile/components/birthYearSlider/BirthYearSlider.tsx
@@ -1,10 +1,369 @@
-interface BirthYearSliderPropTypes {
-  value: number | null;
-  onChange: (birthYear: number | null) => void;
+'use client';
+
+import {
+  type ChangeEvent,
+  type KeyboardEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import useEmblaCarousel from 'embla-carousel-react';
+import { WheelGesturesPlugin } from 'embla-carousel-wheel-gestures';
+
+import * as styles from './birthYearSlider.css';
+
+const DEFAULT_MIN_YEAR = 1910;
+const DEFAULT_MAX_YEAR = 2026;
+const DEFAULT_YEAR = 2000;
+
+type YearTone = 'selected' | 'near' | 'far';
+
+interface BirthYearSliderProps {
+  value?: number;
+  onChange: (year: number) => void;
+  minYear?: number;
+  maxYear?: number;
 }
 
-const BirthYearSlider = ({ value, onChange }: BirthYearSliderPropTypes) => {
-  return <div>{/* TODO: 태어난 연도 선택 컴포넌트 구현 */}</div>;
+const clampYear = (year: number, minYear: number, maxYear: number) =>
+  Math.min(Math.max(year, minYear), maxYear);
+
+const BirthYearSlider = ({
+  value = DEFAULT_YEAR,
+  onChange,
+  minYear = DEFAULT_MIN_YEAR,
+  maxYear = DEFAULT_MAX_YEAR,
+}: BirthYearSliderProps) => {
+  const selectedYear = clampYear(value, minYear, maxYear);
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+
+  const years = useMemo(
+    () =>
+      Array.from(
+        {
+          length: maxYear - minYear + 1,
+        },
+        (_, index) => minYear + index,
+      ),
+    [minYear, maxYear],
+  );
+
+  const wheelPlugin = useMemo(() => WheelGesturesPlugin(), []);
+
+  const [emblaRef, emblaApi] = useEmblaCarousel(
+    {
+      align: 'center',
+
+      // 양 끝 연도도 가운데에 위치할 수 있도록
+      // 시작과 끝의 빈 공간을 유지
+      containScroll: false,
+
+      loop: false,
+      dragFree: false,
+      skipSnaps: false,
+      slidesToScroll: 1,
+      startIndex: selectedYear - minYear,
+    },
+    [wheelPlugin],
+  );
+
+  const [isEditing, setIsEditing] = useState(false);
+
+  const [draftYear, setDraftYear] = useState(String(selectedYear));
+
+  const [errorMessage, setErrorMessage] = useState('');
+
+  /**
+   * 연도를 선택하고 해당 연도 위치로 슬라이더 이동
+   */
+  const selectYear = useCallback(
+    (year: number, jump = false) => {
+      const nextYear = clampYear(year, minYear, maxYear);
+
+      const targetIndex = nextYear - minYear;
+
+      setIsEditing(false);
+      setDraftYear(String(nextYear));
+      setErrorMessage('');
+
+      emblaApi?.scrollTo(targetIndex, jump);
+
+      if (nextYear !== selectedYear) {
+        onChange(nextYear);
+      }
+    },
+    [emblaApi, maxYear, minYear, onChange, selectedYear],
+  );
+
+  /**
+   * 드래그나 트랙패드 이동이 끝난 뒤
+   * 가운데 위치한 연도를 선택값으로 반영
+   */
+  const handleEmblaSelect = useCallback(() => {
+    if (!emblaApi) return;
+
+    const selectedIndex = emblaApi.selectedScrollSnap();
+
+    const nextYear = years[selectedIndex];
+
+    if (nextYear === undefined) return;
+
+    setIsEditing(false);
+    setDraftYear(String(nextYear));
+    setErrorMessage('');
+
+    if (nextYear !== selectedYear) {
+      onChange(nextYear);
+    }
+  }, [emblaApi, onChange, selectedYear, years]);
+
+  useEffect(() => {
+    if (!emblaApi) return;
+
+    emblaApi.on('select', handleEmblaSelect);
+    emblaApi.on('reInit', handleEmblaSelect);
+
+    return () => {
+      emblaApi.off('select', handleEmblaSelect);
+      emblaApi.off('reInit', handleEmblaSelect);
+    };
+  }, [emblaApi, handleEmblaSelect]);
+
+  /**
+   * 부모 컴포넌트에서 value가 변경된 경우
+   * 해당 연도로 슬라이더 위치 동기화
+   */
+  useEffect(() => {
+    if (!emblaApi) return;
+
+    const targetIndex = selectedYear - minYear;
+
+    if (emblaApi.selectedScrollSnap() !== targetIndex) {
+      emblaApi.scrollTo(targetIndex);
+    }
+
+    setDraftYear(String(selectedYear));
+  }, [emblaApi, minYear, selectedYear]);
+
+  useEffect(() => {
+    viewportRef.current?.focus({ preventScroll: true });
+  }, []);
+
+  const handleViewportBlur = () => {
+    if (isEditing) {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      viewportRef.current?.focus({ preventScroll: true });
+    });
+  };
+
+  /**
+   * 선택된 가운데 연도를 직접 입력 모드로 전환
+   */
+  const startEditing = () => {
+    setDraftYear(String(selectedYear));
+    setErrorMessage('');
+    setIsEditing(true);
+  };
+
+  const cancelEditing = () => {
+    setDraftYear(String(selectedYear));
+    setErrorMessage('');
+    setIsEditing(false);
+  };
+
+  /**
+   * 직접 입력한 연도 검증 및 반영
+   */
+  const commitInput = () => {
+    const parsedYear = Number(draftYear);
+
+    const isValid =
+      /^\d{4}$/.test(draftYear) &&
+      Number.isInteger(parsedYear) &&
+      parsedYear >= minYear &&
+      parsedYear <= maxYear;
+
+    if (!isValid) {
+      setErrorMessage(`${minYear}년부터 ${maxYear}년 사이로 입력해주세요.`);
+
+      return false;
+    }
+
+    selectYear(parsedYear);
+
+    return true;
+  };
+
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const numericValue = event.target.value.replace(/\D/g, '');
+
+    setDraftYear(numericValue.slice(0, 4));
+    setErrorMessage('');
+  };
+
+  const adjustDraftYear = useCallback(
+    (delta: number) => {
+      const nextYear = clampYear(Number(draftYear || selectedYear) + delta, minYear, maxYear);
+
+      setDraftYear(String(nextYear));
+      setErrorMessage('');
+    },
+    [draftYear, maxYear, minYear, selectedYear],
+  );
+
+  const handleInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      commitInput();
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      cancelEditing();
+      return;
+    }
+
+    if (event.key === 'ArrowUp' || event.key === 'PageUp') {
+      event.preventDefault();
+      adjustDraftYear(event.key === 'PageUp' ? 10 : 1);
+      return;
+    }
+
+    if (event.key === 'ArrowDown' || event.key === 'PageDown') {
+      event.preventDefault();
+      adjustDraftYear(event.key === 'PageDown' ? -10 : -1);
+    }
+  };
+
+  /**
+   * 슬라이더 키보드 이동
+   */
+  const handleSliderKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.target instanceof HTMLInputElement) {
+      return;
+    }
+
+    switch (event.key) {
+      case 'ArrowLeft':
+        event.preventDefault();
+        selectYear(selectedYear - 1);
+        break;
+
+      case 'ArrowRight':
+        event.preventDefault();
+        selectYear(selectedYear + 1);
+        break;
+
+      case 'Home':
+        event.preventDefault();
+        selectYear(minYear);
+        break;
+
+      case 'End':
+        event.preventDefault();
+        selectYear(maxYear);
+        break;
+
+      case 'Enter':
+        event.preventDefault();
+        startEditing();
+        break;
+
+      default:
+        break;
+    }
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      <div
+        ref={(element) => {
+          emblaRef(element);
+          viewportRef.current = element;
+        }}
+        className={styles.viewport}
+        tabIndex={0}
+        role="group"
+        aria-label={`출생 연도 선택. 현재 선택된 연도는 ${selectedYear}년입니다.`}
+        onKeyDown={handleSliderKeyDown}
+        onBlur={handleViewportBlur}
+      >
+        <div className={styles.container}>
+          {years.map((year) => {
+            const distance = Math.abs(year - selectedYear);
+
+            const tone: YearTone = distance === 0 ? 'selected' : distance === 1 ? 'near' : 'far';
+
+            const isSelected = year === selectedYear;
+
+            return (
+              <div key={year} className={styles.slide}>
+                {isSelected && isEditing ? (
+                  <input
+                    autoFocus
+                    type="text"
+                    inputMode="numeric"
+                    pattern="[0-9]*"
+                    maxLength={4}
+                    value={draftYear}
+                    className={styles.yearInput}
+                    aria-label={`출생 연도 직접 입력. ${minYear}년부터 ${maxYear}년까지 입력할 수 있습니다.`}
+                    onChange={handleInputChange}
+                    onKeyDown={handleInputKeyDown}
+                    onFocus={(event) => event.currentTarget.select()}
+                    onBlur={() => {
+                      const isCommitted = commitInput();
+
+                      if (!isCommitted) {
+                        setDraftYear(String(selectedYear));
+                        setIsEditing(false);
+                      }
+                    }}
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    className={styles.yearButton({
+                      tone,
+                    })}
+                    tabIndex={isSelected ? 0 : -1}
+                    aria-current={isSelected ? 'true' : undefined}
+                    aria-label={
+                      isSelected
+                        ? `${year}년, 현재 선택됨. 다시 누르면 직접 입력할 수 있습니다.`
+                        : `${year}년 선택`
+                    }
+                    onClick={() => {
+                      if (isSelected) {
+                        startEditing();
+                        return;
+                      }
+
+                      selectYear(year);
+                    }}
+                  >
+                    {year}
+                  </button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {errorMessage && (
+        <p className={styles.errorMessage} role="alert">
+          {errorMessage}
+        </p>
+      )}
+    </div>
+  );
 };
 
 export default BirthYearSlider;

--- a/src/app/(main)/balenz-test/profile/components/birthYearSlider/birthYearSlider.css.ts
+++ b/src/app/(main)/balenz-test/profile/components/birthYearSlider/birthYearSlider.css.ts
@@ -1,0 +1,158 @@
+import { color, media, typography } from '@/shared/styles';
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+export const wrapper = style({
+  position: 'relative',
+  width: '100%',
+  height: '5.3125rem',
+
+  '@media': {
+    [media.mobile]: {
+      height: '4.25rem',
+    },
+  },
+});
+
+export const viewport = style({
+  position: 'relative',
+  width: '100%',
+  height: '100%',
+  overflow: 'hidden',
+  borderRadius: '0.625rem',
+  backgroundColor: '#FCFCFC',
+  outline: 'none',
+  touchAction: 'pan-y pinch-zoom',
+  boxShadow: '0 20px 30px 0 rgba(39, 39, 39, 0.02)',
+  padding: '1.25rem 3.125rem',
+
+  '@media': {
+    [media.tablet]: {
+      padding: '1.25rem 1.875rem',
+      boxShadow: '0 8px 15px 0 rgba(39, 39, 39, 0.08)',
+    },
+  },
+
+  selectors: {
+    '&::before': {
+      content: '',
+      position: 'absolute',
+      inset: 0,
+      zIndex: 1,
+      background: 'linear-gradient(90deg, #FCFCFC 0%, rgba(252, 252, 252, 0.00) 50%, #FCFCFC 100%)',
+      pointerEvents: 'none',
+    },
+
+    '&:focus-visible': {
+      //   outline: '2px solid #1a1a1a',
+      //   outlineOffset: '4px',
+    },
+  },
+});
+
+export const container = style({
+  display: 'flex',
+  alignItems: 'center',
+});
+
+export const slide = style({
+  display: 'flex',
+  flex: '0 0 25%',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minWidth: 0,
+});
+
+export const yearButton = recipe({
+  base: {
+    border: 0,
+    backgroundColor: 'transparent',
+
+    fontFamily: 'inherit',
+    cursor: 'pointer',
+
+    transition: 'color 200ms ease, font-size 100ms ease, font-weight 200ms ease',
+  },
+
+  variants: {
+    tone: {
+      selected: {
+        color: color.text.main,
+        ...typography.desktop.display,
+
+        '@media': {
+          [media.tablet]: typography.tablet.display,
+          [media.mobile]: typography.phone.h1,
+        },
+      },
+
+      near: {
+        color: color.text.tertiary,
+        ...typography.desktop.h1,
+
+        '@media': {
+          [media.tablet]: typography.tablet.h1,
+          [media.mobile]: typography.phone.h2,
+        },
+      },
+
+      far: {
+        color: color.text.tertiary,
+        ...typography.desktop.h2,
+
+        '@media': {
+          [media.tablet]: typography.tablet.h2,
+          [media.mobile]: typography.phone.h2,
+        },
+      },
+    },
+  },
+
+  defaultVariants: {
+    tone: 'far',
+  },
+});
+
+export const yearInput = style({
+  display: 'block',
+  width: '100%',
+  margin: 0,
+  padding: 0,
+  boxSizing: 'border-box',
+
+  appearance: 'none',
+  WebkitAppearance: 'none',
+  MozAppearance: 'textfield',
+
+  fontFamily: 'inherit',
+  letterSpacing: 'inherit',
+  textAlign: 'center',
+
+  border: 0,
+  outline: 0,
+  backgroundColor: 'transparent',
+
+  color: color.text.main,
+  ...typography.desktop.display,
+
+  '@media': {
+    [media.tablet]: typography.tablet.display,
+    [media.mobile]: typography.phone.h1,
+  },
+});
+
+export const errorMessage = style({
+  position: 'absolute',
+  top: 'calc(100% + 12px)',
+  left: 0,
+  width: '100%',
+
+  color: color.system.error,
+  ...typography.desktop.caption,
+  textAlign: 'center',
+
+  '@media': {
+    [media.tablet]: typography.tablet.caption,
+    [media.mobile]: typography.phone.caption,
+  },
+});

--- a/src/app/(main)/balenz-test/profile/page.css.ts
+++ b/src/app/(main)/balenz-test/profile/page.css.ts
@@ -70,10 +70,10 @@ export const birthYearNavigationArea = style({
 
   '@media': {
     [media.tablet]: {
-      marginTop: '4rem',
+      marginTop: '23.62rem',
     },
     [media.mobile]: {
-      marginTop: '3rem',
+      marginTop: '22.56rem',
     },
   },
 });

--- a/src/app/(main)/balenz-test/profile/page.tsx
+++ b/src/app/(main)/balenz-test/profile/page.tsx
@@ -20,7 +20,7 @@ export default function ProfilePage() {
 
   const [currentStep, setCurrentStep] = useState<ProfileStepTypes>('birthYear');
 
-  const [selectedBirthYear, setSelectedBirthYear] = useState<number | null>(null);
+  const [selectedBirthYear, setSelectedBirthYear] = useState<number>(2000);
   const [selectedGender, setSelectedGender] = useState<GenderType | null>(null);
 
   const isBirthYearStep = currentStep === 'birthYear';
@@ -35,17 +35,9 @@ export default function ProfilePage() {
   };
 
   const handleNext = () => {
-    // TODO: BirthYearSlider 구현 후 출생 연도 선택 여부에 따라 다음 단계로 이동
-    // if (isBirthYearStep) {
-    //   if (selectedBirthYear === null) return;
-
-    //   setCurrentStep('gender');
-    //   return;
-    // }
-
-    // TODO: BirthYearSlider 구현 전 임시 처리
     if (isBirthYearStep) {
-      setSelectedBirthYear(2026);
+      if (selectedBirthYear === null) return;
+
       setCurrentStep('gender');
       return;
     }

--- a/src/app/(main)/balenz-test/profile/page.tsx
+++ b/src/app/(main)/balenz-test/profile/page.tsx
@@ -36,8 +36,6 @@ export default function ProfilePage() {
 
   const handleNext = () => {
     if (isBirthYearStep) {
-      if (selectedBirthYear === null) return;
-
       setCurrentStep('gender');
       return;
     }
@@ -88,7 +86,7 @@ export default function ProfilePage() {
           <StepNavigation
             showPrevious
             showSkip={!isBirthYearStep}
-            isNextDisabled={isBirthYearStep ? selectedBirthYear === null : selectedGender === null}
+            isNextDisabled={isBirthYearStep ? false : selectedGender === null}
             onPrevious={handlePrevious}
             onNext={handleNext}
             onSkip={handleSkip}

--- a/src/app/(main)/balenz-test/profile/page.tsx
+++ b/src/app/(main)/balenz-test/profile/page.tsx
@@ -88,11 +88,7 @@ export default function ProfilePage() {
           <StepNavigation
             showPrevious
             showSkip={!isBirthYearStep}
-            // TODO: BirthYearSlider 구현 후 출생 연도 선택 여부도 버튼 활성화 조건에 반영
-            // isNextDisabled={isBirthYearStep ? selectedBirthYear === null : selectedGender === null}
-
-            // TODO: BirthYearSlider 구현 전 임시 처리
-            isNextDisabled={!isBirthYearStep && selectedGender === null}
+            isNextDisabled={isBirthYearStep ? selectedBirthYear === null : selectedGender === null}
             onPrevious={handlePrevious}
             onNext={handleNext}
             onSkip={handleSkip}


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #216 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- 프로필 페이지의 응답자 정보 입력 플로우를 구성
- 출생 연도 입력 단계에서 `BirthYearSlider`를 새로 구현해, 연도를 스크롤형 슬라이더로 선택할 수 있도록 추가
- `BirthYearSlider`는 `value`와 `onChange` props를 받아 부모 컴포넌트의 상태와 연동되며, 선택된 연도가 상위 상태로 반영되어 프로필 입력 흐름과 자연스럽게 연결되도록 구성
- 내부적으로는 `selectedYear`를 기준으로 현재 선택된 연도를 중앙에 유지하고, `draftYear` 상태로 입력 모드에서 임시 값을 관리
- `isEditing` 상태를 통해 선택 모드와 직접 입력 모드를 분기하고, `errorMessage` 상태로 유효성 검증 결과를 별도 영역에 표시하도록 처리
- 일반 모드에서는 클릭, 드래그, 좌우 방향키, `Home`/`End` 키로 연도를 변경할 수 있고, 현재 선택된 연도를 다시 클릭하면 직접 입력 모드로 전환
- 직접 입력 모드에서는 숫자만 입력 가능하도록 제한하고, `Enter`로 반영, `Escape`로 취소, `ArrowUp`/`ArrowDown`, `PageUp`/`PageDown`으로 값을 증감할 수 있도록 처리
- 입력값이 허용 범위를 벗어나면 에러 메시지를 노출하도록 구현했으며, 메시지 영역을 별도로 분리해 기존 레이아웃 높이가 흔들리지 않도록 안정화
- 페이지 진입 시 슬라이더가 자동으로 포커스를 받아 키보드로 즉시 조작할 수 있도록 했고, 선택된 연도와 주변 연도의 시각적 강조를 조정해 연도 변경 시 레이아웃이 흔들리지 않도록 정리
- `StepHeader`, `StepNavigation`, `GenderOptionCard` 등을 연결해 프로필 단계별 흐름이 하나의 연속된 입력 경험으로 이어지도록 정리
- 반응형 레이아웃과 공통 z-index 토큰을 함께 반영해 화면 크기와 레이어 우선순위가 자연스럽게 동작하도록 구현


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
#### BirthYearSlider 핵심 로직
- `value`가 바뀌면 `selectedYear` 기준으로 슬라이더 위치를 동기화합니다.
- `selectYear()`는 선택된 연도를 클램프 처리한 뒤, 해당 인덱스로 슬라이더를 이동시키고 상위 상태에 `onChange`로 반영합니다.
- `handleEmblaSelect()`는 Embla의 선택 이벤트가 발생하면 가운데에 위치한 연도를 기준으로 현재 값을 갱신합니다.
- 입력 모드에서는 `draftYear`에 임시값을 저장하고, `commitInput()`에서 4자리 숫자이면서 범위 안에 있으면 반영합니다.
- 잘못된 값이 들어오면 `errorMessage`를 설정하고, 기존 입력값은 유지해 사용자가 수정할 수 있게 했습니다.

## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
https://github.com/user-attachments/assets/2dc4a988-c97b-4826-a8f7-9edb4077f2b5
영상에서는 아래 순서로 각 동작을 확인하실 수 있습니다.
1. 연도를 클릭 또는 터치하여 선택
2. 키보드 방향키를 이용해 연도 선택
3. 화면을 터치한 상태로 좌우로 밀어 연도 선택
4. 노트북 트랙패드의 좌우 스크롤을 이용해 연도 선택
5. 가운데 선택값을 클릭한 뒤 연도 직접 입력
*원활한 확인을 위해 화면 배경색을 임시로 설정했습니다.

<br/>
<br/>

| Desktop | Tablet | Mobile |
| --- | --- | --- |
| <img width="1440" height="777" alt="스크린샷 2026-08-01 오후 10 07 09" src="https://github.com/user-attachments/assets/d08d391d-1e0f-4387-86c9-f6232c2650ad" /> | <img width="775" height="777" alt="스크린샷 2026-08-01 오후 10 07 54" src="https://github.com/user-attachments/assets/61631b5d-dde8-4a53-a835-8cd0bc08de28" /> | <img width="309" height="670" alt="스크린샷 2026-08-01 오후 10 10 06" src="https://github.com/user-attachments/assets/36724725-3e33-4bc5-b941-4d89d5268fbd" /> |

## 📚 Reference
<!-- 참고한 아티클 링크 / 새롭게 알게 된 점이 있다면 적어주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 출생 연도를 캐러셀과 휠 제스처로 선택할 수 있습니다.
  * 연도 직접 입력, 키보드 탐색, 입력 취소 및 범위 조정을 지원합니다.
  * 잘못된 연도 입력 시 오류 메시지를 표시합니다.
  * 선택한 출생 연도에 따라 다음 단계로 진행할 수 있습니다.

* **접근성 및 스타일 개선**
  * 선택 상태와 입력 영역에 접근성 속성을 적용했습니다.
  * 데스크톱, 태블릿, 모바일 화면에 맞춘 반응형 레이아웃을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->